### PR TITLE
DEC-112 Implement a page that redirects to the current exhibit for a collection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,9 +63,9 @@ group :development, :test do
   gem "guard-rails"
   gem "guard-rspec"
   gem "guard-spring"
-  gem "growl"
-  gem "ruby_gntp"
-  gem "growl-rspec"
+#  gem "growl"
+#  gem "ruby_gntp"
+#  gem "growl-rspec"
 
   gem 'coveralls', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,10 +145,6 @@ GEM
       faraday (>= 0.7.4, < 0.10)
     ffi (1.9.6)
     formatador (0.2.5)
-    growl (1.0.3)
-    growl-rspec (3.0.0)
-      growl
-      rspec (~> 3.0)
     guard (2.7.3)
       formatador (>= 0.2.4)
       listen (~> 2.7)
@@ -267,7 +263,6 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    ruby_gntp (0.3.4)
     rubycas-client (2.3.9)
       activesupport
     sass (3.2.19)
@@ -346,8 +341,6 @@ DEPENDENCIES
   devise_cas_authenticatable
   draper
   faker
-  growl
-  growl-rspec
   guard (~> 2.7.3)
   guard-bundler
   guard-coffeescript
@@ -367,7 +360,6 @@ DEPENDENCIES
   react-rails (~> 1.0.0.pre)!
   rspec-collection_matchers
   rspec-rails
-  ruby_gntp
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
   showdown-rails

--- a/app/controllers/collection_redirect_controller.rb
+++ b/app/controllers/collection_redirect_controller.rb
@@ -1,0 +1,11 @@
+class CollectionRedirectController < ApplicationController
+
+  def index
+    redirect_to exhibits_path
+  end
+
+  def show
+    redirect_to CollectionRedirect.call(params[:id])
+  end
+
+end

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -9,7 +9,11 @@ class ExhibitsController < ApplicationController
   end
 
   def new
-    @exhibit = Exhibit.new(collection_id: 1)
+    if params[:collection_id]
+      @exhibit = Exhibit.new(collection_id: params[:collection_id])
+    else
+      @exhibit = Exhibit.new(collection_id: 1)
+    end
   end
 
   def create

--- a/app/services/collection_redirect.rb
+++ b/app/services/collection_redirect.rb
@@ -1,4 +1,5 @@
 class CollectionRedirect
+  attr_reader :collection_id
 
   def self.call(collection_id)
     new(collection_id).find_and_redirect
@@ -9,7 +10,7 @@ class CollectionRedirect
   end
 
   def find_and_redirect
-    @exhibit = Exhibit.find_by(collection_id:  @collection_id)
+    @exhibit = Exhibit.find_by(collection_id:  collection_id)
     if @exhibit
       exhibit_path @exhibit
     else
@@ -17,15 +18,15 @@ class CollectionRedirect
     end
   end
 
+  private
+
   def new_exhibit_path
-    h.new_exhibit_path(collection_id: @collection_id)
+    h.new_exhibit_path(collection_id: collection_id)
   end
 
   def exhibit_path(id)
     h.exhibit_path(id)
   end
-
-  private
 
   def h
     Rails.application.routes.url_helpers

--- a/app/services/collection_redirect.rb
+++ b/app/services/collection_redirect.rb
@@ -1,0 +1,33 @@
+class CollectionRedirect
+
+  def self.call(collection_id)
+    new(collection_id).find_and_redirect
+  end
+
+  def initialize(collection_id)
+    @collection_id = collection_id
+  end
+
+  def find_and_redirect
+    @exhibit = Exhibit.find_by(collection_id:  @collection_id)
+    if @exhibit
+      exhibit_path @exhibit
+    else
+      new_exhibit_path
+    end
+  end
+
+  def new_exhibit_path
+    h.new_exhibit_path(collection_id: @collection_id)
+  end
+
+  def exhibit_path(id)
+    h.exhibit_path(id)
+  end
+
+  private
+
+  def h
+    Rails.application.routes.url_helpers
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
     resources :items, only: [:index, :show], defaults: {format: :json}
   end
 
+   resources :collections, only: [:index, :show], controller: 'collection_redirect'
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/spec/services/collection_redirect_spec.rb
+++ b/spec/services/collection_redirect_spec.rb
@@ -9,14 +9,14 @@ describe CollectionRedirect do
 
     it "redirects to the exhibit" do
       expect(Exhibit).to receive("find_by").with({collection_id: 1}).and_return(:exhibit)
-      subject
+      expect(subject).to eq("/exhibits/exhibit")
     end
   end
 
   context "collection does not have an exhibit" do
     it "redirects to new collection page with collection id set" do
       expect(Exhibit).to receive("find_by").with({collection_id: 1}).and_return(nil)
-      subject
+      expect(subject).to eq("/exhibits/new?collection_id=1")
     end
   end
 

--- a/spec/services/collection_redirect_spec.rb
+++ b/spec/services/collection_redirect_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe CollectionRedirect do
+
+  subject { described_class.call(1) }
+
+  context "collection has an exhibit" do
+    let(:exhibit) { double(Exhibit, id: 1) }
+
+    it "redirects to the exhibit" do
+      expect(Exhibit).to receive("find_by").with({collection_id: 1}).and_return(:exhibit)
+      subject
+    end
+  end
+
+  context "collection does not have an exhibit" do
+    it "redirects to new collection page with collection id set" do
+      expect(Exhibit).to receive("find_by").with({collection_id: 1}).and_return(nil)
+      subject
+    end
+  end
+
+end


### PR DESCRIPTION
Create routes for collections/:collection_id that either redirects to exhibits/:id or to the new exhibits page with collection id set to :collection_id.