### PR TITLE
Use the collection image as a background on the landing page

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -38,6 +38,7 @@ CollectionsListItem = require('./components/collection/CollectionsListItem');
 CollectionLink = require('./components/collection/CollectionLink');
 CollectionShow = require('./components/collection/CollectionShow');
 CollectionDescription = require('./components/collection/CollectionDescription');
+CollectionBackground = require('./components/collection/CollectionBackground');
 
 // Showcases
 ShowcasesList = require('./components/showcase/ShowcasesList');

--- a/app/assets/javascripts/components/collection/CollectionBackground.jsx
+++ b/app/assets/javascripts/components/collection/CollectionBackground.jsx
@@ -1,0 +1,34 @@
+var React = require('react');
+
+var CollectionBackground = React.createClass({
+  propTypes: {
+    collection: React.PropTypes.object.isRequired,
+  },
+
+  style: function() {
+    var styles = {};
+    if (this.props.collection.image) {
+      styles = {
+        backgroundImage: "url(\"" + this.props.collection.image['thumbnail/medium'].contentUrl + "\")",
+      };
+    }
+    return styles;
+  },
+
+  className: function() {
+    if (this.props.collection.image) {
+      return "collection-background";
+    } else {
+      return "";
+    }
+  },
+
+  render: function() {
+    return (
+      <div style={this.style()} className={this.className()}>
+      </div>
+    )
+  }
+});
+
+module.exports = CollectionBackground;

--- a/app/assets/javascripts/components/pages/CollectionShowPage.jsx
+++ b/app/assets/javascripts/components/pages/CollectionShowPage.jsx
@@ -25,7 +25,7 @@ var CollectionShowPage = React.createClass({
         collection: this.props.collection,
       });
     } else {
-      this.loadRemoteCollection()
+      this.loadRemoteCollection();
     }
   },
 
@@ -50,6 +50,7 @@ var CollectionShowPage = React.createClass({
     }
     return (
       <div>
+        <CollectionBackground collection={this.state.collection} />
         <CollectionDescriptionModal collection={this.state.collection} height={this.state.height} />
         <Layout>
           <CollectionPageHeader collection={this.state.collection} />

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -274,6 +274,18 @@ body .jumbotron, .container .jumbotron, .container-fluid .jumbotron {
   }
 }
 
+.collection-background {
+  background-color: none;
+  background-size: cover;
+  bottom: 0;
+  filter: blur(20px);
+  left: 0;
+  opacity: 0.3;
+  position: absolute;
+  right: 0;
+  top: 50px;
+}
+
 .jumbotron .collection-text {
   float: left;
   clear: left;


### PR DESCRIPTION
This adds a blurred background image on the collection landing page, using the collection's primary image.

I added a new component that sits behind the content of the collection landing page, based on prototype work that Andy did.

![digital_exhibits_and_collections](https://cloud.githubusercontent.com/assets/127832/7398386/a8c916bc-ee7c-11e4-81a5-27130d2dac07.png)
