### PR TITLE
Collection Landing page Mobile Optimizations

### DIFF
--- a/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
+++ b/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
@@ -19,7 +19,7 @@ var CollectionPageHeader = React.createClass({
           </a>
           <ul className="nav navbar-nav navbar-left">
             <li><p>|</p></li>
-            <li><a href={showcaseBrowseUrl}>Showcases</a></li>
+            <li><a href={showcaseBrowseUrl}>Featured Content</a></li>
             <li><p>|</p></li>
             <li><a href={itemBrowseUrl}>Items</a></li>
           </ul>

--- a/app/assets/javascripts/components/showcase/ShowcasesList.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcasesList.jsx
@@ -40,7 +40,7 @@ var ShowcasesList = React.createClass({
 
         <div className="showcases-list">
           <div className="">
-            <h2>Showcases</h2>
+            <h2>Featured Content</h2>
             <div className="row">{showcaseNodes}</div>
           </div>
         </div>

--- a/app/assets/stylesheets/_media-medium.css.scss
+++ b/app/assets/stylesheets/_media-medium.css.scss
@@ -4,7 +4,7 @@ $break-medium: 768px;
 @media screen and (max-width: $break-medium) {
 
   .brand-bar {
-    font-size: .75em;
+    font-size: 0.75em;
   }
 
   .title-bar {
@@ -25,7 +25,7 @@ $break-medium: 768px;
   }
 
   .modal-dialog {
-    margin: 0px !important;
+    margin: 0 !important;
     position: relative !important;
   }
 
@@ -33,7 +33,7 @@ $break-medium: 768px;
     height: auto !important;
   }
 
-  ul.navbar-nav {
+  .navbar-nav {
 
     li:first-of-type {
       display: none;

--- a/app/assets/stylesheets/_media-medium.css.scss
+++ b/app/assets/stylesheets/_media-medium.css.scss
@@ -15,9 +15,18 @@ $break-medium: 768px;
     z-index: 6000;
   }
 
+  .modal-body > div {
+    height: 100% !important;
+    overflow-y: auto !important;
+  }
+
+  .modal-content {
+    height: auto !important;
+  }
+
   .modal-dialog {
     margin: 0px !important;
-    height: 100% !important;
+    position: relative !important;
   }
 
   .navbar-brand {
@@ -29,5 +38,15 @@ $break-medium: 768px;
     li:first-of-type {
       display: none;
     }
+  }
+
+  .section-description,
+  #modal-collection-description .collection-description {
+    font-size: 22px;
+    margin: 1em;
+  }
+
+  .collection-description {
+    margin: 1em 1em 2em !important;
   }
 }

--- a/app/assets/stylesheets/_media-medium.css.scss
+++ b/app/assets/stylesheets/_media-medium.css.scss
@@ -6,4 +6,28 @@ $break-medium: 768px;
   .brand-bar {
     font-size: .75em;
   }
+
+  .title-bar {
+    max-height: none;
+  }
+
+  .modal.in {
+    z-index: 6000;
+  }
+
+  .modal-dialog {
+    margin: 0px !important;
+    height: 100% !important;
+  }
+
+  .navbar-brand {
+    height: auto !important;
+  }
+
+  ul.navbar-nav {
+
+    li:first-of-type {
+      display: none;
+    }
+  }
 }

--- a/app/assets/stylesheets/_media-medium.css.scss
+++ b/app/assets/stylesheets/_media-medium.css.scss
@@ -1,0 +1,9 @@
+$break-medium: 768px;
+
+
+@media screen and (max-width: $break-medium) {
+
+  .brand-bar {
+    font-size: .75em;
+  }
+}

--- a/app/assets/stylesheets/_media-medium.css.scss
+++ b/app/assets/stylesheets/_media-medium.css.scss
@@ -21,16 +21,16 @@ $break-medium: 768px;
   }
 
   .modal-content {
-    height: auto !important;
+    height: auto;
   }
 
   .modal-dialog {
     margin: 0 !important;
-    position: relative !important;
+    position: relative;
   }
 
   .navbar-brand {
-    height: auto !important;
+    height: auto;
   }
 
   .navbar-nav {
@@ -47,6 +47,6 @@ $break-medium: 768px;
   }
 
   .collection-description {
-    margin: 1em 1em 2em !important;
+    margin: 1em 1em 2em;
   }
 }

--- a/app/assets/stylesheets/_media-small.css.scss
+++ b/app/assets/stylesheets/_media-small.css.scss
@@ -6,7 +6,7 @@ $break-small: 480px;
 
   .brand-bar {
     font-size: 0.5em;
-    padding-top: 5px;
     height: 22px;
+    padding-top: 5px;
   }
 }

--- a/app/assets/stylesheets/_media-small.css.scss
+++ b/app/assets/stylesheets/_media-small.css.scss
@@ -1,0 +1,12 @@
+$break-small: 480px;
+
+
+
+@media screen and (max-width: $break-small) {
+
+  .brand-bar {
+    font-size: .5em;
+    padding-top: 5px;
+    height: 22px;
+  }
+}

--- a/app/assets/stylesheets/_media-small.css.scss
+++ b/app/assets/stylesheets/_media-small.css.scss
@@ -5,7 +5,7 @@ $break-small: 480px;
 @media screen and (max-width: $break-small) {
 
   .brand-bar {
-    font-size: .5em;
+    font-size: 0.5em;
     padding-top: 5px;
     height: 22px;
   }

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -152,7 +152,7 @@ h1, h2, h3, h4, h5, h6 {
 .navbar-nav > li {
   float: left;
 
-  & > a {
+  a {
     padding: 15px !important;
   }
 }

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -685,6 +685,10 @@ body.collection {
 
 .showcase {
   padding: 0;
+
+  .row {
+    margin-top: 15px;
+  }
 }
 
 .showcase-title-page {

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -149,8 +149,12 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 1em;
 }
 
-.navbar-nav > li > a {
-  padding: 15px !important;
+.navbar-nav > li {
+  float: left;
+
+  & > a {
+    padding: 15px !important;
+  }
 }
 
 .title-bar {
@@ -188,8 +192,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .navbar-nav {
-  position: relative;
   bottom: 0;
+  margin: 0;
+  position: relative;
 }
 
 .navbar-right {
@@ -1073,22 +1078,13 @@ body.collection {
 
 
 .col-sm-6 {
+  float: left;
   width: 50%;
-  float: left;
-}
-
-.navbar-nav > li {
-  float: left;
 }
 
 .navbar-left {
   float: left !important;
 }
-
-.navbar-nav {
-  margin: 0;
-}
-
 
 @import "_material-design-overwrites.scss";
 

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -86,6 +86,10 @@ body {
       p {
         font-size:18px;
       }
+
+      a:hover {
+        text-decoration: none;
+      }
     }
   }
 
@@ -1067,4 +1071,27 @@ body.collection {
   right: 40px;
 }
 
+
+.col-sm-6 {
+  width: 50%;
+  float: left;
+}
+
+.navbar-nav > li {
+  float: left;
+}
+
+.navbar-left {
+  float: left !important;
+}
+
+.navbar-nav {
+  margin: 0;
+}
+
+
 @import "_material-design-overwrites.scss";
+
+// media-query stylesheet
+@import "_media-medium.css.scss";
+@import "_media-small.css.scss";


### PR DESCRIPTION
Added media-query stylesheets for page breaks at 480 and 768.
Reduce branding size, expand title height to accommodate long titles on small screens (<768).
Change modals to cover more of the screen, with less margin/padding and use a smaller font on small screens.