### PR TITLE
Branding Changes to Top of Page

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -18,6 +18,7 @@ PageContent = require('./components/layout/PageContent');
 CollectionPageHeader = require('./components/layout/CollectionPageHeader');
 GridList = require('./components/layout/GridList');
 Card = require('./components/layout/Card');
+BrandBar = require('./components/layout/BrandBar');
 
 // Pages
 CollectionsListPage = require('./components/pages/CollectionsListPage');

--- a/app/assets/javascripts/components/layout/BrandBar.jsx
+++ b/app/assets/javascripts/components/layout/BrandBar.jsx
@@ -1,0 +1,24 @@
+var React = require('react');
+
+var BrandBar = React.createClass({
+
+  render: function() {
+    return (
+      <div className="brand-bar">
+        <div className="container-fluid">
+          <div className="row">
+            <div className="col-sm-6">
+              <a href="http://www.nd.edu">University <i>of</i> Notre Dame</a>
+            </div>
+            <div className="col-sm-6">
+              <a className="pull-right" href="http://library.nd.edu">Hesburgh Libraries</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+});
+
+module.exports = BrandBar;

--- a/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
+++ b/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
@@ -6,13 +6,14 @@ var CollectionPageHeader = React.createClass({
 
   propTypes: {
     collection: React.PropTypes.object.isRequired,
+    branding: React.PropTypes.bool,
   },
 
   render: function() {
     var itemBrowseUrl = "/" + this.props.collection.id + "/" + this.props.collection.slug + "/items";
     var showcaseBrowseUrl = "/" + this.props.collection.id + "/" + this.props.collection.slug + "/showcases";
     return (
-      <PageHeader>
+    <PageHeader branding={this.props.branding}>
         <TitleBar>
           <a className="navbar-brand" href={this.collectionUrl(this.props.collection)}>
             {this.props.collection.title}

--- a/app/assets/javascripts/components/layout/PageHeader.jsx
+++ b/app/assets/javascripts/components/layout/PageHeader.jsx
@@ -18,18 +18,7 @@ var PageHeader = React.createClass({
     var branding;
     if(this.props.branding) {
       branding = (
-        <div className="brand-bar">
-          <div className="container-fluid">
-            <div className="row">
-              <div className="col-sm-6">
-                <a href="http://www.nd.edu">University <i>of</i> Notre Dame</a>
-              </div>
-              <div className="col-sm-6">
-                <a className="pull-right" href="http://library.nd.edu">Hesburgh Libraries</a>
-              </div>
-            </div>
-          </div>
-        </div>
+        <BrandBar />
       );
     }
 

--- a/app/assets/javascripts/components/layout/PageHeader.jsx
+++ b/app/assets/javascripts/components/layout/PageHeader.jsx
@@ -1,7 +1,13 @@
-//app/assets/javascripts/components/SectionsListItem.jsx
+//app/assets/javascripts/components/layout/PageHeader.jsx
 var React = require('react');
 
 var PageHeader = React.createClass({
+  displayName: 'Page Header',
+
+  propTypes: {
+    branding: React.PropTypes.bool,
+  },
+
   render: function() {
     var titleBar = this.props.children;
     if (!titleBar) {
@@ -9,21 +15,28 @@ var PageHeader = React.createClass({
         <TitleBar />
       );
     }
-    return (
-      <header id="banner" role="banner" className="home">
-        <nav className="navbar navbar-default navbar-static-top" role="navigation">
-          <div className="brand-bar">
-            <div className="container-fluid">
-              <div className="row">
-                <div className="col-sm-6">
-                  <a href="http://www.nd.edu">University <i>of</i> Notre Dame</a>
-                </div>
-                <div className="col-sm-6">
-                  <a className="pull-right" href="http://library.nd.edu">Hesburgh Libraries</a>
-                </div>
+    var branding;
+    if(this.props.branding) {
+      branding = (
+        <div className="brand-bar">
+          <div className="container-fluid">
+            <div className="row">
+              <div className="col-sm-6">
+                <a href="http://www.nd.edu">University <i>of</i> Notre Dame</a>
+              </div>
+              <div className="col-sm-6">
+                <a className="pull-right" href="http://library.nd.edu">Hesburgh Libraries</a>
               </div>
             </div>
           </div>
+        </div>
+      );
+    }
+
+    return (
+      <header id="banner" role="banner" className="home">
+        <nav className="navbar navbar-default navbar-static-top" role="navigation">
+          {branding}
           {titleBar}
         </nav>
       </header>

--- a/app/assets/javascripts/components/pages/CollectionShowPage.jsx
+++ b/app/assets/javascripts/components/pages/CollectionShowPage.jsx
@@ -58,7 +58,7 @@ var CollectionShowPage = React.createClass({
       <div className="collection-show-page" style={this.style()}>
         <CollectionBackground collection={this.state.collection} />
         <Layout>
-          <CollectionPageHeader collection={this.state.collection} />
+        <CollectionPageHeader collection={this.state.collection} branding={true} />
           <PageContent>
             <CollectionShow collection={this.state.collection} />
             <hr />

--- a/app/assets/javascripts/components/pages/CollectionsListPage.jsx
+++ b/app/assets/javascripts/components/pages/CollectionsListPage.jsx
@@ -42,7 +42,7 @@ var CollectionsListPage = React.createClass({
   render: function() {
     return (
       <Layout>
-        <PageHeader />
+      <PageHeader branding={true} />
         <PageContent>
           <div className="banner">
             <div className="container">

--- a/app/assets/javascripts/components/pages/ShowcaseShowPage.jsx
+++ b/app/assets/javascripts/components/pages/ShowcaseShowPage.jsx
@@ -28,8 +28,9 @@ var ShowcaseShowPage = React.createClass({
     this.setState({
       collection: collection,
       showcase: collection.showcases,
-    });
+    }, this.handleResize);
   },
+
   modals: function() {
     if(this.state.showcase) {
       return (<SectionsModalList height={this.state.height} sections={this.state.showcase.sections} />);

--- a/app/assets/javascripts/components/showcase/ShowcaseTitleBar.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseTitleBar.jsx
@@ -42,7 +42,9 @@ var ShowcaseTitleBar = React.createClass({
     if (this.props.showcase) {
       return (
         <div className="showcases-title-bar" id="showcases-title-bar" style={this.style()}>
-          <h2 style={this.titleStyle()}>{this.props.showcase.title}</h2>
+          <h2 style={this.titleStyle()} title={this.props.showcase.title}>
+            {this.props.showcase.title}
+          </h2>
         </div>
       );
     } else {

--- a/app/assets/stylesheets/_media-medium.css.scss
+++ b/app/assets/stylesheets/_media-medium.css.scss
@@ -25,7 +25,8 @@ $break-medium: 768px;
   }
 
   .modal-dialog {
-    margin: 0 !important;
+    margin-left: 0;
+    margin-right: 0;
     position: relative;
   }
 

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -221,12 +221,15 @@ h1, h2, h3, h4, h5, h6 {
 
   h2 {
     font-size: 16px;
-    text-transform: uppercase;
     font-family: GPCMed;
     font-weight: normal;
-    padding: 0;
-    margin: 0;
     letter-spacing: 1.1px;
+    margin: 0;
+    overflow: hidden;
+    padding: 0;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
   }
 }
 

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -832,21 +832,11 @@ div.dataTables_filter {
 }
 
 #banner {
-  z-index: 5000;
-  position: fixed;
   width: 100%;
 
   p {
     margin: 0;
   }
-}
-
-#banner + div {
-  padding-top: 100px;
-}
-
-.collections-bg #banner + div {
-  padding-top:50px;
 }
 
 .modal-header {


### PR DESCRIPTION
Only Show top ND/Hesburgh branding on the Site landing page, and the individual collection homepage.

Added a boolean of "branding" to the PageHeader (and CollectionPageHeader) components. This way any page can show the branding by passing branding={true}. Currently set on CollectionsListPage and CollectionsShowPage.