### PR TITLE
Dec 252 - Improve the nav experience on beehive

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -55,6 +55,7 @@ ShowcaseTitle = require('./components/showcase/ShowcaseTitle');
 ShowcaseTitleBar = require('./components/showcase/ShowcaseTitleBar');
 ShowcaseBackground = require('./components/showcase/ShowcaseBackground');
 ShowcaseCard = require('./components/showcase/ShowcaseCard');
+ShowcaseDropDown = require('./components/showcase/ShowcaseDropDown');
 
 // Sections
 SectionsList = require('./components/section/SectionsList');

--- a/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
+++ b/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
@@ -10,14 +10,17 @@ var CollectionPageHeader = React.createClass({
   },
 
   render: function() {
-    var itemBrowseUrl = "/" + this.props.collection.id + "/" + this.props.collection.slug + "/items";
-    var showcaseBrowseUrl = "/" + this.props.collection.id + "/" + this.props.collection.slug + "/showcases";
+    var dropdown = "";
+    if(this.props.collection['@id']) {
+      dropdown = (<ShowcaseDropDown collection={this.props.collection} />);
+    }
     return (
     <PageHeader branding={this.props.branding}>
         <TitleBar>
+          {dropdown}
           <a className="navbar-brand" href={this.collectionUrl(this.props.collection)}>
-            <span className="title">{this.props.collection.title_line_1}</span>             <span className="subtitle">{this.props.collection.title_line_2}</span>
-
+            <span className="title">{this.props.collection.title_line_1}</span>
+            <span className="subtitle">{this.props.collection.title_line_2}</span>
           </a>
         </TitleBar>
       </PageHeader>

--- a/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
+++ b/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
@@ -16,7 +16,8 @@ var CollectionPageHeader = React.createClass({
     <PageHeader branding={this.props.branding}>
         <TitleBar>
           <a className="navbar-brand" href={this.collectionUrl(this.props.collection)}>
-            {this.props.collection.title}
+            <span className="title">{this.props.collection.title_line_1}</span>             <span className="subtitle">{this.props.collection.title_line_2}</span>
+
           </a>
         </TitleBar>
       </PageHeader>

--- a/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
+++ b/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
@@ -18,12 +18,6 @@ var CollectionPageHeader = React.createClass({
           <a className="navbar-brand" href={this.collectionUrl(this.props.collection)}>
             {this.props.collection.title}
           </a>
-          <ul className="nav navbar-nav navbar-left">
-            <li><p>|</p></li>
-            <li><a href={showcaseBrowseUrl}>Featured Content</a></li>
-            <li><p>|</p></li>
-            <li><a href={itemBrowseUrl}>Items</a></li>
-          </ul>
         </TitleBar>
       </PageHeader>
     );

--- a/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
@@ -1,0 +1,75 @@
+var React = require('react');
+
+var ShowcaseDropDown = React.createClass({
+  mixins: [CollectionUrlMixin],
+
+  propTypes: {
+    collection: React.PropTypes.object.isRequired,
+  },
+
+  getInitialState: function() {
+    return {
+      showcases: [],
+    };
+  },
+
+  style: function() {
+    return{
+      float: "left",
+      marginLeft: "15px",
+    };
+  },
+
+  buttonStyle: function() {
+    return {
+      background: "transparent",
+      border: "1px #f5f5f5 solid",
+      height: "40px",
+      width: "40px",
+      padding: "0",
+      marginTop: "10px",
+      marginLeft: "10px",
+    };
+  },
+
+  componentDidMount: function() {
+    var url = this.props.collection['@id'] + '/showcases';
+    console.log("URL", url);
+    $.get(url, function(result) {
+      var showcases = result.showcases;
+      console.log(showcases);
+      if (this.isMounted()) {
+        this.setState({
+          showcases: showcases,
+        });
+      }
+    }.bind(this));
+  },
+
+  render: function() {
+    var dropDownOptions = [];
+    var collectionUrl = this.collectionUrl(this.props.collection);
+
+    this.state.showcases.forEach(function(showcase){
+    var url = collectionUrl + "/showcases/" + encodeURIComponent(showcase.id) + "/" + encodeURIComponent(showcase.slug);
+    dropDownOptions.push ((
+      <li className="dropdown-header" value={showcase.id}>
+      <a href={url}>
+          {showcase.title}
+        </a>
+      </li>));
+    });
+
+    return (
+    <div className="btn-group featured-content-dropdown" style={this.style()}>
+        <button data-toggle="dropdown" className="btn dropdown-toggle btn-primary" type="button" style={this.buttonStyle()}><span className="caret"></span></button>
+        <ul className="dropdown-menu" role="menu">
+        {dropDownOptions}
+        </ul>
+      </div>
+    );
+  }
+
+});
+
+module.exports = ShowcaseDropDown;

--- a/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
@@ -35,7 +35,25 @@ var ShowcaseDropDown = React.createClass({
   componentDidMount: function() {
     var url = this.props.collection['@id'] + '/showcases';
     console.log("URL", url);
-    $.get(url, function(result) {
+
+    $.ajax({
+      url: url,
+      success: function(result) {
+        var showcases = result.showcases;
+        console.log(showcases);
+        if (this.isMounted()) {
+          this.setState({
+            showcases: showcases,
+          });
+        }
+      }.bind(this),
+    });
+
+
+  },
+
+/*
+  $.get(url, function(result) {
       var showcases = result.showcases;
       console.log(showcases);
       if (this.isMounted()) {
@@ -45,6 +63,7 @@ var ShowcaseDropDown = React.createClass({
       }
     }.bind(this));
   },
+*/
 
   render: function() {
     var dropDownOptions = [];

--- a/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
@@ -34,36 +34,21 @@ var ShowcaseDropDown = React.createClass({
 
   componentDidMount: function() {
     var url = this.props.collection['@id'] + '/showcases';
-    console.log("URL", url);
 
-    $.ajax({
-      url: url,
-      success: function(result) {
-        var showcases = result.showcases;
-        console.log(showcases);
-        if (this.isMounted()) {
-          this.setState({
-            showcases: showcases,
-          });
-        }
-      }.bind(this),
-    });
+    var request = new XMLHttpRequest();
+    request.open('GET', url, true);
 
-
-  },
-
-/*
-  $.get(url, function(result) {
-      var showcases = result.showcases;
-      console.log(showcases);
+    request.onload = function() {
+      var showcases = JSON.parse(request.response).showcases;
       if (this.isMounted()) {
         this.setState({
           showcases: showcases,
         });
       }
-    }.bind(this));
+    }.bind(this);
+
+    request.send();
   },
-*/
 
   render: function() {
     var dropDownOptions = [];

--- a/app/assets/javascripts/components/showcase/ShowcaseTitle.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseTitle.jsx
@@ -62,7 +62,10 @@ var ShowcaseTitle = React.createClass({
     return (
       <div className="showcase-title-page" style={this.outerStyle()}>
         <div className="showcase-title-page-inner" style={this.innerStyle()}>
-          <h2 className="showcase-title-primary" style={this.headerStyle()}>{this.props.showcase.title}</h2>
+          <h2 className="showcase-title-primary" style={this.headerStyle()}>
+            <span className="title">{this.props.showcase.title_line_1}</span>&nbsp;
+            <span className="subtitle">{this.props.showcase.title_line_2}</span>
+          </h2>
           <div className="showcase-title-description" dangerouslySetInnerHTML={{__html: description}}  />
         </div>
       </div>

--- a/app/assets/javascripts/components/showcase/ShowcaseTitleBar.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseTitleBar.jsx
@@ -39,7 +39,6 @@ var ShowcaseTitleBar = React.createClass({
   },
 
   render: function() {
-    console.log(this.props.showcase);
     if (this.props.showcase) {
       return (
         <div className="showcases-title-bar" id="showcases-title-bar" style={this.style()}>

--- a/app/assets/javascripts/components/showcase/ShowcaseTitleBar.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseTitleBar.jsx
@@ -39,11 +39,13 @@ var ShowcaseTitleBar = React.createClass({
   },
 
   render: function() {
+    console.log(this.props.showcase);
     if (this.props.showcase) {
       return (
         <div className="showcases-title-bar" id="showcases-title-bar" style={this.style()}>
           <h2 className="showcases-title-bar-title overflow-ellipsis" style={this.titleStyle()} title={this.props.showcase.title}>
-            {this.props.showcase.title}
+          <span className="title">{this.props.showcase.title_line_1}</span>&nbsp;
+          <span className="subtitle">{this.props.showcase.title_line_2}</span>
           </h2>
         </div>
       );

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -291,7 +291,7 @@ body .jumbotron, .container .jumbotron, .container-fluid .jumbotron {
 
   .subtitle {
     display: block;
-    font-size: .6em;
+    font-size: 0.6em;
   }
 }
 

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -283,6 +283,14 @@ body .jumbotron, .container .jumbotron, .container-fluid .jumbotron {
   }
 }
 
+.showcase-title-primary {
+
+  .subtitle {
+    display: block;
+    font-size: .6em;
+  }
+}
+
 .flow-columns {
   -webkit-column-count: 4;
   -webkit-column-gap: 10px;

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -95,8 +95,12 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .navbar .navbar-brand {
-  height: 50px;
-  line-height: 1em;
+  height: auto;
+  line-height: 1.2em;
+
+  .subtitle {
+    display: block;
+  }
 }
 
 .navbar-nav > li {
@@ -118,7 +122,7 @@ h1, h2, h3, h4, h5, h6 {
   border-bottom: solid 1px #999;
   background: rgba(51, 51, 51, 0.95);
   background: rgba(0, 0, 0, 0.86);
-  max-height: 50px;
+  max-height: none;
 }
 
 .navbar-default a {


### PR DESCRIPTION
253
---

* Added a dropdown list of all available showcases in a collection. 
* Created a new ShowcaseDropDown React component. 
* Since the individual showcases do not know about the other showcases, I had to do an additional ajax request using the collection/showcases url to pull in their titles and build their links.

254
---

* Removed the "featured content" and "items" links from the title bar. With the new dropdown menu the featured content link was redundant.

255
---

* Made the title bar larger.
* Titles may be split along two lines by use of the new .title_line_1 and .title_line_2 elements.
* Also split the titles across two lines for several "cards" because it was essentially the same change as above.