### PR TITLE
Replace Collection Intro Modal with a Page

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -26,6 +26,7 @@ CollectionOverlayFooter = require('./components/layout/CollectionOverlayFooter')
 // Pages
 CollectionsListPage = require('./components/pages/CollectionsListPage');
 CollectionShowPage = require('./components/pages/CollectionShowPage');
+CollectionIntroPage = require('./components/pages/CollectionIntroPage');
 ShowcasesListPage = require('components/pages/ShowcasesListPage');
 ShowcaseShowPage = require('./components/pages/ShowcaseShowPage');
 SectionShowPage= require('./components/pages/SectionShowPage');
@@ -46,6 +47,7 @@ CollectionLink = require('./components/collection/CollectionLink');
 CollectionShow = require('./components/collection/CollectionShow');
 CollectionDescription = require('./components/collection/CollectionDescription');
 CollectionIntro = require('./components/collection/CollectionIntro');
+CollectionIntroLink = require('./components/collection/CollectionIntroLink');
 CollectionBackground = require('./components/collection/CollectionBackground');
 
 // Showcases
@@ -85,7 +87,6 @@ Copyright = require('./components/modal/Copyright');
 Info = require('./components/modal/Info');
 SectionModal = require('./components/modal/SectionModal');
 ItemModal = require('./components/modal/ItemModal');
-CollectionDescriptionModal = require('./components/modal/CollectionDescriptionModal');
 
 // Other
 MetadataList = require('./components/other/MetadataList');

--- a/app/assets/javascripts/components/collection/CollectionIntroLink.jsx
+++ b/app/assets/javascripts/components/collection/CollectionIntroLink.jsx
@@ -1,7 +1,9 @@
 //app/assets/javascripts/components/modal/CollectionDescriptionModal.jsx
 var React = require('react');
 
-var CollectionDescriptionModal = React.createClass({
+var CollectionIntroLink = React.createClass({
+  mixins: [CollectionUrlMixin],
+
   displayName: 'Item Modal',
   propTypes: {
     collection: React.PropTypes.object.isRequired,
@@ -28,16 +30,13 @@ var CollectionDescriptionModal = React.createClass({
   },
 
   render: function () {
-    var content = this.content();
+    var url = this.collectionUrl(this.props.collection) + "/intro";
     return (
-      <div>
-        <Modal height={this.props.height} id="modal-collection-description" className="modal-collection-description" content={content} />
         <div className="well">
-          <h1><a href="#modal-collection-description" data-toggle="modal" data-target="#modal-collection-description"> Introduction</a></h1>
+          <h1><a href={url}> Introduction</a></h1>
         </div>
-      </div>
     );
   }
 });
 
-module.exports = CollectionDescriptionModal;
+module.exports = CollectionIntroLink;

--- a/app/assets/javascripts/components/pages/CollectionIntroPage.jsx
+++ b/app/assets/javascripts/components/pages/CollectionIntroPage.jsx
@@ -1,0 +1,51 @@
+var React = require('react');
+
+var CollectionIntroPage = React.createClass({
+  displayName: 'Collection Intro Page',
+
+  propTypes: {
+    collection: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.object,
+    ]),
+  },
+
+  getInitialState: function() {
+    return {
+      collection: {},
+    };
+  },
+
+  componentDidMount: function() {
+    if ('object' == typeof(this.props.collection)) {
+      this.setState({
+        collection: this.props.collection,
+      });
+    } else {
+      this.loadRemoteCollection();
+    }
+  },
+
+  loadRemoteCollection: function() {
+    $.get(this.props.collection, function(result) {
+      this.setState({
+        collection: result,
+      });
+    }.bind(this));
+  },
+
+  render: function() {
+    return (
+      <div className="collection-intro-page">
+        <Layout>
+          <CollectionPageHeader collection={this.state.collection} dropdown={true} />
+          <PageContent>
+            <CollectionDescription collection={this.state.collection} />
+          </PageContent>
+        </Layout>
+      </div>
+    );
+  }
+});
+
+module.exports = CollectionIntroPage;

--- a/app/assets/javascripts/components/pages/CollectionShowPage.jsx
+++ b/app/assets/javascripts/components/pages/CollectionShowPage.jsx
@@ -57,7 +57,7 @@ var CollectionShowPage = React.createClass({
             <PageContent>
               <CollectionShow collection={this.state.collection} />
               <hr />
-              <CollectionDescriptionModal collection={this.state.collection} height={this.state.height} />
+              <CollectionIntroLink collection={this.state.collection} height={this.state.height} />
               {showcasesList}
             </PageContent>
           </Layout>

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -546,6 +546,13 @@ div.dataTables_filter {
   height: 100%;
 }
 
+.collection-intro-page {
+
+  .collection-description {
+    font-size: 24px;
+    margin: 20px;
+  }
+}
 
 /* nav panel */
 
@@ -738,7 +745,7 @@ div.dataTables_filter {
 
     i {
       color: $white;
-      font-size: 34px;
+      font-size: 20px;
       text-shadow: 1px 1px 1px #000;
     }
   }

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -5,15 +5,19 @@ class CollectionsController < ApplicationController
     @collections_url = collections_api_base
   end
 
+  def intro
+    @collections_url = collections_api_base + "/" + params[:id] + "/showcases"
+  end
+
   def embed
-    @collections_url =  collections_api_base + "/" + params[:id] + "/showcases"
+    @collections_url = collections_api_base + "/" + params[:id] + "/showcases"
     respond_to do |format|
       format.html {render :layout => "embed"}
     end
   end
 
   def show
-    @collections_url =  collections_api_base + "/" + params[:id] + "/showcases"
+    @collections_url = collections_api_base + "/" + params[:id] + "/showcases"
   end
 
   private

--- a/app/views/collections/intro.html.erb
+++ b/app/views/collections/intro.html.erb
@@ -1,0 +1,1 @@
+<%= react_component('CollectionIntroPage', collection: @collections_url) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root to: "collections#index"
 
   get "/:id/:slug", to: "collections#show"
+  get "/:id/:slug/intro", to: "collections#intro"
 
   scope "/:collection_id/:collection_slug" do
     scope "/showcases" do


### PR DESCRIPTION
* Removed Collection Introduction Modal.
* Create Collection Introduction Page - (added route,  controller action, view, and React components).
* Modified and renamed React component CollectionDescriptionModal to CollectionIntroLink.
* Replaced link to modal with link to Introduction page.
* Added some basic css so it doesn't look too bad.