### PR TITLE
Dec 338

### DIFF
--- a/app/assets/javascripts/components/collection/CollectionIntroLink.jsx
+++ b/app/assets/javascripts/components/collection/CollectionIntroLink.jsx
@@ -30,19 +30,18 @@ var CollectionIntroLink = React.createClass({
   },
 
   render: function () {
-    var url;
-    if(this.props.collection.showcases){
-      if(this.props.collection.showcases.length > 0) {
-        url = this.showcaseUrl(this.props.collection.showcases[0]);
-      }
-    }
-    return (
-      <div className="row">
-        <div className="col-md-12 bee-browse-exhibit" >
-          <h2><a href={url}> Browse Exhibit <i className="mdi-navigation-arrow-forward"></i> </a> </h2>
+    var firstShowcase = this.firstShowcaseUrl(this.props.collection.showcase);
+    if(firstShowcase) {
+      return (
+        <div className="row">
+          <div className="col-md-12 bee-browse-exhibit" >
+            <h2><a href={firstShowcase}> Browse Exhibit <i className="mdi-navigation-arrow-forward"></i> </a> </h2>
+          </div>
         </div>
-      </div>
-    );
+      );
+    } else {
+      return (<div />);
+    }
   }
 });
 

--- a/app/assets/javascripts/components/collection/CollectionIntroLink.jsx
+++ b/app/assets/javascripts/components/collection/CollectionIntroLink.jsx
@@ -30,7 +30,12 @@ var CollectionIntroLink = React.createClass({
   },
 
   render: function () {
-    var url = this.introUrl(this.props.collection);
+    var url;
+    if(this.props.collection.showcases){
+      if(this.props.collection.showcases.length > 0) {
+        url = this.showcaseUrl(this.props.collection.showcases[0]);
+      }
+    }
     return (
       <div className="row">
         <div className="col-md-12 bee-browse-exhibit" >

--- a/app/assets/javascripts/components/collection/CollectionShow.jsx
+++ b/app/assets/javascripts/components/collection/CollectionShow.jsx
@@ -65,12 +65,6 @@ var CollectionShow = React.createClass({
   },
 
   render: function() {
-    var url;
-    if(this.props.collection.showcases){
-      if(this.props.collection.showcases.length > 0) {
-        url = this.showcaseUrl(this.props.collection.showcases[0]);
-      }
-    }
     var overflow = this.state.overflow;
     var titleStyle = {};
     var buttonStyle = {};
@@ -87,13 +81,17 @@ var CollectionShow = React.createClass({
       else {
         buttonStyle = {margin: "4em auto 0",};
       }
+      var firstShowcaseLink;
+      if(this.firstShowcaseUrl(this.props.collection.showcase)) {
+        firstShowcaseLink = (<a href={this.firstShowcaseUrl(this.props.collection.showcase)} className="btn btn-lg btn-success start" style={buttonStyle}>Exhibit <i className="mdi-navigation-chevron-right"></i></a>);
+      }
       return (
         <div className="jumbotron">
           <div className="collection-show">
             <div className="collection-text">
               <h1 style={titleStyle}>{this.props.collection.name}</h1>
               <Thumbnail image={this.props.collection.image} />
-                  <a href={url} className="btn btn-lg btn-success start" style={buttonStyle}>Exhibit <i className="mdi-navigation-chevron-right"></i></a>
+              {firstShowcaseLink}
               <div className="row">
                 <div className="collection-image col-md-12">
                 </div>

--- a/app/assets/javascripts/components/collection/CollectionShow.jsx
+++ b/app/assets/javascripts/components/collection/CollectionShow.jsx
@@ -65,7 +65,12 @@ var CollectionShow = React.createClass({
   },
 
   render: function() {
-    var intro_url = this.introUrl(this.props.collection);
+    var url;
+    if(this.props.collection.showcases){
+      if(this.props.collection.showcases.length > 0) {
+        url = this.showcaseUrl(this.props.collection.showcases[0]);
+      }
+    }
     var overflow = this.state.overflow;
     var titleStyle = {};
     var buttonStyle = {};
@@ -88,7 +93,7 @@ var CollectionShow = React.createClass({
             <div className="collection-text">
               <h1 style={titleStyle}>{this.props.collection.name}</h1>
               <Thumbnail image={this.props.collection.image} />
-                  <a href={intro_url} className="btn btn-lg btn-success start" style={buttonStyle}>Exhibit <i className="mdi-navigation-chevron-right"></i></a>
+                  <a href={url} className="btn btn-lg btn-success start" style={buttonStyle}>Exhibit <i className="mdi-navigation-chevron-right"></i></a>
               <div className="row">
                 <div className="collection-image col-md-12">
                 </div>

--- a/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
@@ -53,7 +53,6 @@ var ShowcaseDropDown = React.createClass({
   dropDownOptions: function() {
     var options = [];
     var collectionUrl = this.collectionUrl(this.props.collection);
-    var introUrl = this.introUrl(this.props.collection);
 
     options.push((
       <li className="dropdown-header" value={this.props.collection.id}>
@@ -63,12 +62,6 @@ var ShowcaseDropDown = React.createClass({
 
     options.push((
       <hr/>
-    ));
-
-    options.push((
-      <li className="dropdown-header" value={this.props.collection.id}>
-        <a href={introUrl}>Introduction</a>
-      </li>
     ));
 
     this.state.showcases.forEach(function(showcase){

--- a/app/assets/javascripts/mixins/CollectionUrlMixin.jsx
+++ b/app/assets/javascripts/mixins/CollectionUrlMixin.jsx
@@ -8,6 +8,16 @@ var CollectionUrlMixin = {
     return this.collectionObjectUrl('showcases', showcase);
   },
 
+  firstShowcaseUrl: function(showcase) {
+    var url;
+    if(this.props.collection.showcases){
+      if(this.props.collection.showcases.length > 0) {
+        url = this.showcaseUrl(this.props.collection.showcases[0]);
+      }
+    }
+    return url;
+  },
+
   itemUrl: function(item) {
     return this.collectionObjectUrl('items', item);
   },

--- a/app/assets/javascripts/mixins/CollectionUrlMixin.jsx
+++ b/app/assets/javascripts/mixins/CollectionUrlMixin.jsx
@@ -1,7 +1,4 @@
 var CollectionUrlMixin = {
-  introUrl: function(collection) {
-    return this.collectionUrl(collection) + '/intro'
-  },
 
   sectionUrl: function(section) {
     return this.collectionObjectUrl('sections', section);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,6 @@ Rails.application.routes.draw do
 
   get "/:id", to: "collections#show"
   get "/:id/:slug", to: "collections#show"
-  get "/:id/:slug/intro", to: "collections#intro"
 
   scope "/:collection_id/:collection_slug" do
     scope "/showcases" do


### PR DESCRIPTION
We decided to take a new approach to the introduction, so we need to remove some of the old stuff. The actual Introduction page jsx still exists, but all links to it and the route to it have been removed.

* Remove Introduction from dropdown.
* Remove Introduction Route
* Remove introUrl from mixin.
* Change intro links to use the first showcase because this will be where the new introduction goes.