### PR TITLE
DEC-324: add padding to the showcase 

### DIFF
--- a/app/assets/javascripts/components/showcase/ShowcaseShow.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseShow.jsx
@@ -3,7 +3,7 @@ var React = require('react');
 
 var maxShowcaseHeight = 840;
 var showcaseTitleHeight = 40;
-var scrollPadding = 40;
+var scrollPadding = 80;
 var titleSectionWidthPercent = 0.75;
 
 var ShowcaseShow = React.createClass({
@@ -68,6 +68,7 @@ var ShowcaseShow = React.createClass({
       left: 0,
       overflowX: 'visible',
       overflowY: 'visible',
+      paddingTop: '20px',
     };
   },
 


### PR DESCRIPTION
The Showcase page could use some breathing room.

* Add an extra 20px of padding to the top and bottom of the showcase. Reduces hight by 40px.