### PR TITLE
DEC-303 Clicking Close on the about window closes the larger window.

### DIFF
--- a/app/assets/javascripts/components/layout/CollectionOverlayFooter.jsx
+++ b/app/assets/javascripts/components/layout/CollectionOverlayFooter.jsx
@@ -5,6 +5,11 @@ var CollectionOverlayFooter = React.createClass({
   propTypes: {
     collection: React.PropTypes.object.isRequired,
   },
+
+  closeOther: function(target) {
+    $(target).modal("hide");
+  },
+
   render: function () {
     return (
       <div>
@@ -13,8 +18,8 @@ var CollectionOverlayFooter = React.createClass({
         <footer id="footer" className="container-fluid">
           <div className="row">
             <div className="col-sm-8 pull-left">
-              <button type="button" className="btn btn-primary" data-toggle="modal" data-target="#info"><i className="mdi-action-info-outline"></i></button>
-              <button type="button" className="btn btn-primary" data-toggle="modal" data-target="#copy"><i className="glyphicon glyphicon-copyright-mark"></i></button>
+              <button type="button" className="btn btn-primary" data-toggle="modal" data-target="#info" onClick={this.closeOther.bind(this, "#copy")}><i className="mdi-action-info-outline"></i></button>
+              <button type="button" className="btn btn-primary" data-toggle="modal" data-target="#copy" onClick={this.closeOther.bind(this, "#info")}><i className="glyphicon glyphicon-copyright-mark"></i></button>
             </div>
             <div className="col-sm-4 pull-right">
               <a href="http://library.nd.edu">

--- a/app/assets/javascripts/components/modal/ItemModal.jsx
+++ b/app/assets/javascripts/components/modal/ItemModal.jsx
@@ -23,7 +23,7 @@ var ItemModal = React.createClass({
   render: function () {
     var itemPage = this.itemPage();
     return (
-      <Modal height={this.props.height} id={this.modalID()} content={itemPage} />
+      <Modal height={this.props.height} id={this.modalID()} content={itemPage} hasHash={true} />
     );
   }
 });

--- a/app/assets/javascripts/components/modal/Modal.jsx
+++ b/app/assets/javascripts/components/modal/Modal.jsx
@@ -9,6 +9,7 @@ var Modal = React.createClass({
     className: React.PropTypes.string,
     content: React.PropTypes.object.isRequired,
     height: React.PropTypes.number,
+    hasHash: React.PropTypes.bool,
   },
 
   styles: function() {
@@ -31,7 +32,9 @@ var Modal = React.createClass({
   },
 
   removeHash: function() {
-    window.location.hash = '';
+    if(this.props.hasHash) {
+      window.location.hash = '';
+    }
   },
 
   onKeyDown: function(event) {

--- a/app/assets/javascripts/components/modal/SectionModal.jsx
+++ b/app/assets/javascripts/components/modal/SectionModal.jsx
@@ -23,7 +23,7 @@ var SectionModal = React.createClass({
   render: function () {
     var sectionPage = this.sectionPage();
     return (
-      <Modal height={this.props.height} id={this.modalID()} content={sectionPage} />
+      <Modal height={this.props.height} id={this.modalID()} content={sectionPage} hasHash={true} />
     );
   }
 });

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -854,7 +854,7 @@ div.dataTables_filter {
 #copy, #info {
 
   .modal-header {
-    height: 30px;
+    height: 50px;
   }
 
   .modal-dialog {


### PR DESCRIPTION
* This action is triggered because closing the window removes the page hash fragment from the URL.
* Fixed this by adding an optional hasHash property that can be passed when creating a modal and passed true for item and section modals.