### PR TITLE
Fix section line height for captions

### DIFF
--- a/app/assets/javascripts/components/section/Section.jsx
+++ b/app/assets/javascripts/components/section/Section.jsx
@@ -24,6 +24,7 @@ var Section = React.createClass({
       marginRight: '20px',
       height: this.props.height + 'px',
       cursor: 'pointer',
+      lineHeight: '20px',
     };
   },
 


### PR DESCRIPTION
When I vertically centered the "Next Showcase" I introduced a bug affecting the height of captions