### PR TITLE
Prevent the titlebar brand link from wrapping

### DIFF
--- a/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
+++ b/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
@@ -27,7 +27,7 @@ var CollectionPageHeader = React.createClass({
     <PageHeader branding={this.props.branding}>
         <TitleBar>
           {dropdown}
-          <a className="navbar-brand" href={this.collectionUrl(this.props.collection)}>
+          <a className="navbar-brand overflow-ellipsis" href={this.collectionUrl(this.props.collection)}>
             {title}
           </a>
         </TitleBar>

--- a/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
@@ -87,8 +87,8 @@ var ShowcaseDropDown = React.createClass({
 
   render: function() {
     return (
-    <div className="btn-group featured-content-dropdown" style={this.style()}>
-        <button data-toggle="dropdown" className="btn dropdown-toggle btn-primary" type="button" style={this.buttonStyle()}><span className="mdi-image-photo-library"></span></button>
+    <div className="btn-group featured-content-dropdown">
+        <button data-toggle="dropdown" className="btn dropdown-toggle btn-primary featured-content-dropdown-button" type="button"><span className="mdi-image-photo-library"></span></button>
         <ul className="dropdown-menu" role="menu">
         {this.dropDownOptions()}
         </ul>

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -11,10 +11,10 @@
  * file per style scope.
  *
  *= require bootstrap_and_overrides
- *= require nav_bar
  *= require prev-next
  *= require_tree ./components
  *= require bootstrap-material-design
+ *= require nav_bar
  *= require perfect-scrollbar
  *= require ui-customizations
  *= require_self

--- a/app/assets/stylesheets/nav_bar.css.scss
+++ b/app/assets/stylesheets/nav_bar.css.scss
@@ -1,4 +1,8 @@
 $navbar-button-background: #2b2a2a;
+$dropdown-button-size: 30px;
+$dropdown-button-padding: 10px;
+$dropdown-button-margin-left: 15px;
+$title-offset: $dropdown-button-size + ($dropdown-button-padding * 2) + $dropdown-button-margin-left;
 
 .brand-bar {
   background-color: #002b5b;
@@ -32,6 +36,7 @@ $navbar-button-background: #2b2a2a;
 
 .navbar-default .title-bar .navbar-brand {
   color: #302205;
+  max-width: calc(100% - #{$title-offset});
 }
 
 .navbar-default .title-bar .navbar-nav > li > a {
@@ -51,6 +56,19 @@ footer {
   .btn-group {
     background-color: $navbar-button-background;
     border-radius: 0;
-    padding: 10px;
+    float: left;
+    margin-left: $dropdown-button-margin-left;
+    padding: $dropdown-button-padding;
+  }
+}
+
+.featured-content-dropdown-button {
+  background: transparent;
+  height: $dropdown-button-size;
+  padding: 0;
+  width: $dropdown-button-size;
+
+  &.btn-primary:not(.btn-link):not(.btn-flat) {
+    background: transparent;
   }
 }


### PR DESCRIPTION
When the title is long enough and/or the browser width is small enough, it causes the title bar to wrap over multiple lines, potentially taking up a large area at the top of the page.  This keeps the title on one line, and overflows with an ellipsis when the entire title can't be displayed.