### PR TITLE
DEC-262: Allow the copyright text to be changed

### DIFF
--- a/app/assets/javascripts/components/layout/CollectionOverlayFooter.jsx
+++ b/app/assets/javascripts/components/layout/CollectionOverlayFooter.jsx
@@ -14,7 +14,7 @@ var CollectionOverlayFooter = React.createClass({
     return (
       <div>
         <Info collection={this.props.collection} />
-        <Copyright />
+        <Copyright collection={this.props.collection} />
         <footer id="footer" className="container-fluid">
           <div className="row">
             <div className="col-sm-8 pull-left">

--- a/app/assets/javascripts/components/modal/Copyright.jsx
+++ b/app/assets/javascripts/components/modal/Copyright.jsx
@@ -9,8 +9,9 @@ var Copyright = React.createClass({
     return (new Date().getFullYear());
   },
   content: function() {
-    if (this.props.collection.copyright)
+    if (this.props.collection.copyright) {
       return(<div dangerouslySetInnerHTML={{__html: this.props.collection.copyright}} />);
+    }
     return (<p><a href="http://www.nd.edu/copyright/">Copyright</a> {this.year()} <a href="http://www.nd.edu">University of Notre Dame</a></p>);
   },
   render: function () {

--- a/app/assets/javascripts/components/modal/Copyright.jsx
+++ b/app/assets/javascripts/components/modal/Copyright.jsx
@@ -2,15 +2,17 @@
 var React = require('react');
 
 var Copyright = React.createClass({
-
-  content: function() {
-    return (<p><a href="http://www.nd.edu/copyright/">Copyright</a> {this.year()} <a href="http://www.nd.edu">University of Notre Dame</a></p>);
+  propTypes: {
+    collection: React.PropTypes.object.isRequired,
   },
-
   year: function () {
     return (new Date().getFullYear());
   },
-
+  content: function() {
+    if (this.props.collection.copyright)
+      return(<div dangerouslySetInnerHTML={{__html: this.props.collection.copyright}} />);
+    return (<p><a href="http://www.nd.edu/copyright/">Copyright</a> {this.year()} <a href="http://www.nd.edu">University of Notre Dame</a></p>);
+  },
   render: function () {
     return (
       <Modal id="copy" content={this.content()} />


### PR DESCRIPTION
WHY: An exhibit creator needs their custom copyright to show on the front end
HOW: Changed the copyright component to first try to use the copyright from the exhibit, if there is none, then it will use the prescribed value (this should almost never happen since the api sets a default value when the user has not specified one)