### PR TITLE
Improve showcase care look

### DIFF
--- a/app/assets/javascripts/components/showcase/ShowcaseTitle.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseTitle.jsx
@@ -32,13 +32,6 @@ var ShowcaseTitle = React.createClass({
     };
   },
 
-  innerStyle: function() {
-    return {
-      width: "85%",
-      display: "inline-block",
-    };
-  },
-
   headerStyle: function() {
     var marginTop;
     if (this.props.height) {
@@ -77,7 +70,7 @@ var ShowcaseTitle = React.createClass({
 
     return (
       <div className="showcase-title-page" style={this.outerStyle()}>
-        <div className="showcase-title-page-inner" style={this.innerStyle()}>
+        <div className="showcase-title-page-inner">
           <div className="showcase-title-container" style={this.headerStyle()}>
             {this.names()}
           </div>

--- a/app/assets/stylesheets/showcase.css.scss
+++ b/app/assets/stylesheets/showcase.css.scss
@@ -61,6 +61,12 @@ $white: #fff;
   }
 }
 
+.showcase-title-page-inner {
+  display: inline-block;
+  max-width: 85%;
+  // text-align: left;
+}
+
 .showcase-name-1,
 .showcase-name-2,
 .showcase-title-container {
@@ -74,6 +80,7 @@ $white: #fff;
   border-width: 1px 0;
   margin-bottom: 1em;
   padding: 1em;
+  text-align: center;
 }
 
 .showcase-name-1,
@@ -84,7 +91,6 @@ $white: #fff;
 
 .showcase-name-1 {
   font-size: 50px;
-  text-align: center;
   white-space: normal;
 }
 
@@ -94,7 +100,8 @@ $white: #fff;
 
 .showcase-title-description-container {
   display: inline-block;
-  margin: 30px auto 0;
+  margin-top: 30px;
+  padding: 0 1em;
 }
 
 .showcase-title-description {
@@ -106,6 +113,10 @@ $white: #fff;
 }
 
 .showcase-card {
+  .showcase-title-page-inner {
+    max-width: 100%;
+  }
+
   .showcase-name-1 {
     font-size: 24px;
   }


### PR DESCRIPTION
The showcase cards currently only use 85% of the width to display text.  This increases that size so the card text doesn't look as cramped