### PR TITLE
Changed grid size, fix intro padding

### DIFF
--- a/app/assets/javascripts/components/collection/CollectionIntro.jsx
+++ b/app/assets/javascripts/components/collection/CollectionIntro.jsx
@@ -7,20 +7,9 @@ var CollectionIntro = React.createClass({
     id: React.PropTypes.string,
   },
 
-  style: function() {
-    if(this.props.height) {
-      return {
-        maxHeight: this.props.height + 'px',
-        overflow: 'hidden',
-      };
-    } else {
-      return {};
-    }
-  },
-
   render: function() {
     return (
-      <div style={this.style()} id={this.props.id}>
+      <div className="collection-short-intro-container" id={this.props.id}>
         <div className="collection-short-intro" dangerouslySetInnerHTML={{__html: this.props.collection.short_description}} />
       </div>
     )

--- a/app/assets/javascripts/components/layout/GridList.jsx
+++ b/app/assets/javascripts/components/layout/GridList.jsx
@@ -2,10 +2,6 @@
 var React = require('react');
 
 var gridSize = 12;
-var grids = {
-  lg: 3,
-  sm: 2,
-};
 
 var GridList = React.createClass({
   propTypes: {
@@ -13,37 +9,55 @@ var GridList = React.createClass({
       React.PropTypes.array,
       React.PropTypes.object,
     ]).isRequired,
+    grids: React.PropTypes.object,
+  },
+
+  getDefaultProps: function () {
+    return {
+      grids: {
+        lg: 3,
+        sm: 2,
+      }
+    };
+  },
+
+  childGridNodes: function(node, index, nodeClass) {
+    var nodes = this.clearfixNodes(index);
+    nodes.push((
+      <div className={nodeClass} key={index}>
+        {node}
+      </div>
+    ));
+    return nodes;
+  },
+
+  clearfixNodes: function(index) {
+    var nodes = [];
+    if (index > 0) {
+      for (var prefix in this.props.grids) {
+        var columns = this.props.grids[prefix];
+        var clearClass = "clearfix visible-" + prefix + "-block";
+        if (index%columns == 0) {
+          nodes.push ((
+            <div className={clearClass} key={index + prefix + "clearfix"} />
+          ));
+        }
+      }
+    }
+    return nodes;
   },
 
   childrenGridNodes: function() {
     var index = 0;
     var childrenNodes = []
     var nodeClass = "";
-    for (var prefix in grids) {
-      var columns = grids[prefix];
+    for (var prefix in this.props.grids) {
+      var columns = this.props.grids[prefix];
       nodeClass += " col-" + prefix + "-" + (gridSize / columns);
     }
-    React.Children.forEach(this.props.children, function(node) {
-      var nodes = [];
-      if (index > 0) {
-        for (var prefix in grids) {
-          var columns = grids[prefix];
-          var clearClass = "clearfix visible-" + prefix + "-block";
-          if (index%columns == 0) {
-            nodes.push ((
-              <div className={clearClass} key={index + prefix + "clearfix"} />
-            ));
-          }
-        }
-      }
-      nodes.push((
-        <div className={nodeClass} key={index}>
-          {node}
-        </div>
-      ));
-      index += 1;
-      childrenNodes.push(nodes);
-    });
+    React.Children.forEach(this.props.children, function(node, index) {
+      childrenNodes.push(this.childGridNodes(node, index, nodeClass));
+    }.bind(this));
     return childrenNodes;
   },
 

--- a/app/assets/javascripts/components/layout/GridList.jsx
+++ b/app/assets/javascripts/components/layout/GridList.jsx
@@ -1,6 +1,12 @@
 //app/assets/javascripts/components/layout/GridList.jsx
 var React = require('react');
 
+var gridSize = 12;
+var grids = {
+  lg: 3,
+  sm: 2,
+};
+
 var GridList = React.createClass({
   propTypes: {
     children: React.PropTypes.oneOfType([
@@ -12,17 +18,26 @@ var GridList = React.createClass({
   childrenGridNodes: function() {
     var index = 0;
     var childrenNodes = []
+    var nodeClass = "";
+    for (var prefix in grids) {
+      var columns = grids[prefix];
+      nodeClass += " col-" + prefix + "-" + (gridSize / columns);
+    }
     React.Children.forEach(this.props.children, function(node) {
       var nodes = [];
       if (index > 0) {
-        if (index%3 == 0) {
-          nodes.push ((
-            <div className="clearfix" key={index + "clearfix"}></div>
-          ));
+        for (var prefix in grids) {
+          var columns = grids[prefix];
+          var clearClass = "clearfix visible-" + prefix + "-block";
+          if (index%columns == 0) {
+            nodes.push ((
+              <div className={clearClass} key={index + prefix + "clearfix"} />
+            ));
+          }
         }
       }
       nodes.push((
-        <div className="col-sm-4" key={index}>
+        <div className={nodeClass} key={index}>
           {node}
         </div>
       ));

--- a/app/assets/stylesheets/collection.css.scss
+++ b/app/assets/stylesheets/collection.css.scss
@@ -63,17 +63,21 @@ body.collection {
   }
 }
 
-.collection-short-intro {
-  font-size: 20px;
-  margin: 0 auto;
-  padding: 15px 15em 15px 15em;
+.collection-short-intro-container {
   background: rgba(244, 244, 244, 0.7);
   box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.75);
-  margin-bottom: 2em;
+  font-size: 20px;
+  margin: 0 0 2em;
+  padding: 1em;
+}
+
+.collection-short-intro {
+  color: $gray20;
+  margin: 0 auto;
+  max-width: 40em;
 
   p:last-child {
     margin-bottom: 0;
-    color: $gray20;
   }
 }
 

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -941,11 +941,6 @@ div.dataTables_filter {
   z-index: 1;
 }
 
-.col-sm-6 {
-  float: left;
-  width: 50%;
-}
-
 .navbar-left {
   float: left !important;
 }


### PR DESCRIPTION
The cards got too small when tiled 3 across at middling width.  They now switch to two across at middle widths, and three across at larger widths.

This also fixes a problem with the short intro size at small widths (was smooshed to one word per line)