### PR TITLE
Fix next showcase card continue button

### DIFF
--- a/app/assets/javascripts/components/showcase/ShowcaseCard.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseCard.jsx
@@ -7,6 +7,7 @@ var ShowcaseCard = React.createClass({
   propTypes: {
     showcase: React.PropTypes.object.isRequired,
     showDescription: React.PropTypes.bool,
+    topChildren: React.PropTypes.any,
   },
 
   getDefaultProps: function () {
@@ -51,6 +52,7 @@ var ShowcaseCard = React.createClass({
             <h3 className="bee-card-content-title-subtitle overflow-ellipsis">{this.props.showcase.name_line_2}</h3>
           </div>
           {this.description()}
+          {this.props.children}
         </div>
       </Card>
     );

--- a/app/assets/javascripts/components/showcase/ShowcaseCard.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseCard.jsx
@@ -41,6 +41,7 @@ var ShowcaseCard = React.createClass({
   render: function() {
     return (
       <Card backgroundImage={this.props.showcase.image}>
+        {this.props.topChildren}
         <div className="showcase-card sixteen-nine" style={this.style()} onClick={this.onClick}>
           <CardOverlay>
             <ShowcaseTitle showcase={this.props.showcase} />

--- a/app/assets/javascripts/components/showcase/ShowcaseEnding.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseEnding.jsx
@@ -25,6 +25,7 @@ var ShowcaseEnding = React.createClass({
 
   buttonStyle: function() {
     return {
+      display: "none",
       position: "absolute",
       top: "27rem",
       left: "0",
@@ -41,15 +42,29 @@ var ShowcaseEnding = React.createClass({
     };
   },
 
+  topTitle: function() {
+    return (
+      <div className="bee-card-content">
+        <div className="bee-card-content-title">
+          <h2 className="bee-card-content-title-primary">Next Showcase</h2>
+        </div>
+      </div>
+    );
+  },
+
   render: function() {
     return (
       <section className="section section-continue" style={this.style()} id="section-ending">
-        <div className="section-container section-container-text" style={this.containerStyle()}>
-            <h2 className="section-container-text-title section-ending-title">Next Showcase</h2>
-            <div style={this.buttonStyle()}>
-              <a href={this.showcaseUrl(this.props.showcase)} className="btn btn-lg btn-success continue"><span>Continue </span><i className="mdi-navigation-chevron-right"></i></a>
+        <div className="section-container" style={this.containerStyle()}>
+          <div style={this.buttonStyle()}>
+            <a href={this.showcaseUrl(this.props.showcase)} className="btn btn-lg btn-success continue"><span>Continue </span><i className="mdi-navigation-chevron-right"></i></a>
+          </div>
+          <ShowcaseCard showcase={this.props.showcase} topChildren={this.topTitle()}>
+            {this.topTitle()}
+            <div className="bee-card-content-actions clearfix">
+              <a href={this.showcaseUrl(this.props.showcase)} className="btn btn-success pull-right"><span>Continue </span><i className="mdi-navigation-chevron-right"></i></a>
             </div>
-            <ShowcaseCard showcase={this.props.showcase} />
+          </ShowcaseCard>
         </div>
       </section>
     );

--- a/app/assets/javascripts/components/showcase/ShowcaseEnding.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseEnding.jsx
@@ -25,9 +25,8 @@ var ShowcaseEnding = React.createClass({
 
   buttonStyle: function() {
     return {
-      display: "none",
       position: "absolute",
-      top: "27rem",
+      bottom: "1em",
       left: "0",
       right: "0",
       textAlign: "center",
@@ -42,6 +41,20 @@ var ShowcaseEnding = React.createClass({
     };
   },
 
+  originalHeader: function() {
+    return (
+      <h2 className="section-container-text-title section-ending-title">Next Showcase</h2>
+    );
+  },
+
+  originalButton: function() {
+    return (
+      <div style={this.buttonStyle()}>
+        <a href={this.showcaseUrl(this.props.showcase)} className="btn btn-lg btn-success continue"><span>Continue </span><i className="mdi-navigation-chevron-right"></i></a>
+      </div>
+    );
+  },
+
   topTitle: function() {
     return (
       <div className="bee-card-content">
@@ -52,18 +65,21 @@ var ShowcaseEnding = React.createClass({
     );
   },
 
+  actions: function() {
+    return (
+      <div className="bee-card-content-actions clearfix">
+        <a href={this.showcaseUrl(this.props.showcase)} className="btn btn-success pull-right"><span>Continue </span><i className="mdi-navigation-chevron-right"></i></a>
+      </div>
+    );
+  },
+
   render: function() {
     return (
       <section className="section section-continue" style={this.style()} id="section-ending">
-        <div className="section-container" style={this.containerStyle()}>
-          <div style={this.buttonStyle()}>
-            <a href={this.showcaseUrl(this.props.showcase)} className="btn btn-lg btn-success continue"><span>Continue </span><i className="mdi-navigation-chevron-right"></i></a>
-          </div>
-          <ShowcaseCard showcase={this.props.showcase} topChildren={this.topTitle()}>
-            {this.topTitle()}
-            <div className="bee-card-content-actions clearfix">
-              <a href={this.showcaseUrl(this.props.showcase)} className="btn btn-success pull-right"><span>Continue </span><i className="mdi-navigation-chevron-right"></i></a>
-            </div>
+        <div className="section-container section-container-text" style={this.containerStyle()}>
+          {this.originalHeader()}
+          <ShowcaseCard showcase={this.props.showcase}>
+            {this.originalButton()}
           </ShowcaseCard>
         </div>
       </section>

--- a/app/assets/javascripts/components/showcase/ShowcaseEnding.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseEnding.jsx
@@ -41,34 +41,10 @@ var ShowcaseEnding = React.createClass({
     };
   },
 
-  originalHeader: function() {
-    return (
-      <h2 className="section-container-text-title section-ending-title">Next Showcase</h2>
-    );
-  },
-
-  originalButton: function() {
+  continueButton: function() {
     return (
       <div style={this.buttonStyle()}>
         <a href={this.showcaseUrl(this.props.showcase)} className="btn btn-lg btn-success continue"><span>Continue </span><i className="mdi-navigation-chevron-right"></i></a>
-      </div>
-    );
-  },
-
-  topTitle: function() {
-    return (
-      <div className="bee-card-content">
-        <div className="bee-card-content-title">
-          <h2 className="bee-card-content-title-primary">Next Showcase</h2>
-        </div>
-      </div>
-    );
-  },
-
-  actions: function() {
-    return (
-      <div className="bee-card-content-actions clearfix">
-        <a href={this.showcaseUrl(this.props.showcase)} className="btn btn-success pull-right"><span>Continue </span><i className="mdi-navigation-chevron-right"></i></a>
       </div>
     );
   },
@@ -77,9 +53,9 @@ var ShowcaseEnding = React.createClass({
     return (
       <section className="section section-continue" style={this.style()} id="section-ending">
         <div className="section-container section-container-text" style={this.containerStyle()}>
-          {this.originalHeader()}
+          <h2 className="section-container-text-title section-ending-title">Next Showcase</h2>
           <ShowcaseCard showcase={this.props.showcase}>
-            {this.originalButton()}
+            {this.continueButton()}
           </ShowcaseCard>
         </div>
       </section>

--- a/app/assets/stylesheets/cards.css.scss
+++ b/app/assets/stylesheets/cards.css.scss
@@ -69,10 +69,10 @@ $action-color: #d9a91b;
     line-height: 24px;
     margin: 0 8px 0 0;
     padding: 8px;
-  }
 
-  .btn.btn-default {
-    color: $action-color;
+    &.btn-default {
+      color: $action-color;
+    }
   }
 
   [class^="mdi-"],

--- a/app/assets/stylesheets/cards.css.scss
+++ b/app/assets/stylesheets/cards.css.scss
@@ -64,11 +64,20 @@ $action-color: #d9a91b;
 .bee-card-content-actions {
   padding: 8px;
 
-  .btn.btn-default {
-    color: $action-color;
-    font-weight: 400;
+  .btn {
+    font-size: 16px;
+    line-height: 24px;
     margin: 0 8px 0 0;
     padding: 8px;
+  }
+
+  .btn.btn-default {
+    color: $action-color;
+  }
+
+  [class^="mdi-"],
+  [class*="mdi-"] {
+    font-size: 16px;
   }
 }
 

--- a/app/assets/stylesheets/showcase.css.scss
+++ b/app/assets/stylesheets/showcase.css.scss
@@ -5,6 +5,7 @@ $title-color: #fff;
 $title-shadow-color: #333;
 $section-border-color: #fff;
 $section-color: #d3d3d3;
+$section-background: rgba(51, 51, 51, 0.95);
 $scrollbar-rail-color: #dedede;
 $scrollbar-color: #666;
 $black: #000;
@@ -147,7 +148,7 @@ $white: #fff;
 }
 
 .section-container-text {
-  background: rgba(51, 51, 51, 0.95);
+  background: $section-background;
   color: $section-color;
   font-size: 14px;
   line-height: 24px;

--- a/app/assets/stylesheets/showcase.css.scss
+++ b/app/assets/stylesheets/showcase.css.scss
@@ -142,6 +142,10 @@ $white: #fff;
   }
 }
 
+.section-container {
+  line-height: 24px;
+}
+
 .section-container-text {
   background: rgba(51, 51, 51, 0.95);
   color: $section-color;


### PR DESCRIPTION
The button was not part of the card, causing its position to vary based on the size of the content. This fixes that by making the button part of the card element.

This also adds some currently unused code for using a more traditional card view for the showcases.