### PR TITLE
DEC-380: Add proper title/subtitle formatting for the drop down box

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -10,6 +10,7 @@ HorizontalScrollMixin = require("./mixins/HorizontalScrollMixin");
 PageHeightMixin = require("./mixins/PageHeightMixin");
 PrevNextMixin = require("./mixins/PrevNextMixin");
 LoadRemoteCollectionMixin = require("./mixins/LoadRemoteCollectionMixin");
+TitleConcatMixin = require("./mixins/TitleConcatMixin");
 
 // Layout
 Layout = require("./components/layout/Layout");

--- a/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
+++ b/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
@@ -2,7 +2,7 @@
 var React = require('react');
 
 var CollectionPageHeader = React.createClass({
-  mixins: [CollectionUrlMixin],
+  mixins: [CollectionUrlMixin, TitleConcatMixin],
 
   propTypes: {
     collection: React.PropTypes.object.isRequired,
@@ -16,12 +16,9 @@ var CollectionPageHeader = React.createClass({
       dropdown = (<ShowcaseDropDown collection={this.props.collection} />);
     }
 
-    var title = [];
-    title.push((<span className="title" key={1}>{this.props.collection.name_line_1}</span>));
+    var fullName = this.titleConcat(this.props.collection.name_line_1, this.props.collection.name_line_2)
+    var title = <span className="title" key={1}>{fullName}</span>;
 
-    if(this.props.collection.name_line_2) {
-      title.push((<span className="subtitle" key={2}>{this.props.collection.name_line_2}</span>));
-    }
 
     return (
     <PageHeader branding={this.props.branding}>

--- a/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
@@ -71,10 +71,9 @@ var ShowcaseDropDown = React.createClass({
       ));
     }
 
-    var showcaseDropDownInstance = this;
     this.state.showcases.forEach(function(showcase){
       var url = collectionUrl + "/showcases/" + encodeURIComponent(showcase.id) + "/" + encodeURIComponent(showcase.slug);
-      var showcaseName = showcaseDropDownInstance.titleConcat(showcase.name_line_1, showcase.name_line_2);
+      var showcaseName = this.titleConcat(showcase.name_line_1, showcase.name_line_2);
       options.push ((
         <li key={showcase.id} className="dropdown-header" value={showcase.id}>
           <a href={url}>
@@ -82,7 +81,7 @@ var ShowcaseDropDown = React.createClass({
           </a>
         </li>
       ));
-    });
+    }.bind(this));
     return options
   },
 

--- a/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseDropDown.jsx
@@ -1,7 +1,7 @@
 var React = require('react');
 
 var ShowcaseDropDown = React.createClass({
-  mixins: [CollectionUrlMixin],
+  mixins: [CollectionUrlMixin, TitleConcatMixin],
 
   propTypes: {
     collection: React.PropTypes.object.isRequired,
@@ -71,13 +71,14 @@ var ShowcaseDropDown = React.createClass({
       ));
     }
 
-
+    var showcaseDropDownInstance = this;
     this.state.showcases.forEach(function(showcase){
       var url = collectionUrl + "/showcases/" + encodeURIComponent(showcase.id) + "/" + encodeURIComponent(showcase.slug);
+      var showcaseName = showcaseDropDownInstance.titleConcat(showcase.name_line_1, showcase.name_line_2);
       options.push ((
         <li key={showcase.id} className="dropdown-header" value={showcase.id}>
           <a href={url}>
-            {showcase.name}
+            {showcaseName}
           </a>
         </li>
       ));

--- a/app/assets/javascripts/components/showcase/ShowcaseTitleBar.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseTitleBar.jsx
@@ -6,6 +6,8 @@ var marginBottom = 5;
 var borderBottom = 1;
 
 var ShowcaseTitleBar = React.createClass({
+  mixins: [TitleConcatMixin],
+
   displayName: 'Showcase Title Bar',
 
   propTypes: {
@@ -39,17 +41,7 @@ var ShowcaseTitleBar = React.createClass({
   },
 
   name: function () {
-    if (this.props.showcase.name_line_2) {
-      return this.props.showcase.name_line_1 + this.nameSpacer() + this.props.showcase.name_line_2;
-    }
-    return this.props.showcase.name_line_1;
-  },
-
-  nameSpacer: function () {
-    if (this.props.showcase.name_line_2) {
-      return ": ";
-    }
-    return "";
+    return this.titleConcat(this.props.showcase.name_line_1, this.props.showcase.name_line_2);
   },
 
   render: function() {
@@ -57,8 +49,7 @@ var ShowcaseTitleBar = React.createClass({
       return (
         <div className="showcases-title-bar" id="showcases-title-bar" style={this.style()}>
           <h2 className="showcases-title-bar-title overflow-ellipsis" style={this.titleStyle()} title={this.name()}>
-          <span className="title">{this.props.showcase.name_line_1}{this.nameSpacer()}</span>&nbsp;
-          <span className="subtitle">{this.props.showcase.name_line_2}</span>
+            <span className="title">{this.name()}</span>
           </h2>
         </div>
       );

--- a/app/assets/javascripts/mixins/TitleConcatMixin.jsx
+++ b/app/assets/javascripts/mixins/TitleConcatMixin.jsx
@@ -1,0 +1,21 @@
+// Concats a title and subtitle using the format specified here http://dissertation.laerd.com/style-guides-for-dissertation-titles-p2.php
+var TitleConcatMixin = {
+  titleConcat: function(title, subtitle) {
+    console.log(title);
+    if(subtitle)
+      return title + this.titleSpacer(title) + subtitle;
+    return title;
+  },
+
+  // Gets the spacer to use after the title. Will
+  // be a : unless there is already a ':' or
+  // there is a '?' at the end
+  titleSpacer: function(title) {
+    var last = title.trim().slice(-1)
+    if(last == "?" || last == ":")
+      return " "
+    return ": "
+  }
+}
+
+module.exports = TitleConcatMixin;

--- a/app/assets/javascripts/mixins/TitleConcatMixin.jsx
+++ b/app/assets/javascripts/mixins/TitleConcatMixin.jsx
@@ -1,7 +1,6 @@
 // Concats a title and subtitle using the format specified here http://dissertation.laerd.com/style-guides-for-dissertation-titles-p2.php
 var TitleConcatMixin = {
   titleConcat: function(title, subtitle) {
-    console.log(title);
     if(subtitle)
       return title + this.titleSpacer(title) + subtitle;
     return title;


### PR DESCRIPTION
WHY: The drop down menu of showcases was not using the "title: subtitle" format
HOW: We had several other places that used this formatting, so I made a TitleConcatMixin to handle this formatting and changed ShowcaseDropDown, CollectionPageHeader, and ShowcaseTitleBar to use it.