### PR TITLE
Update React to 0.13.3

### DIFF
--- a/app/assets/javascripts/components/__tests__/collection/CollectionBackground.spec.jsx
+++ b/app/assets/javascripts/components/__tests__/collection/CollectionBackground.spec.jsx
@@ -1,0 +1,23 @@
+jest.dontMock("../../collection/CollectionBackground");
+
+var React, TestUtils, CollectionBackground, Collection, render;
+
+describe('CollectionBackground', function(){
+  React = require('react/addons');
+  TestUtils = React.addons.TestUtils;
+  CollectionBackground = require('../../collection/CollectionBackground');
+
+
+  Collection = { "image": { "thumbnail/medium": {"contentUrl" : "http://test.local/test.png"}}};
+  this.props = { collection: Collection};
+  render = TestUtils.renderIntoDocument(<CollectionBackground collection={Collection} />);
+
+
+  it("has className 'collection-background'", function() {
+    expect(React.findDOMNode(render).className).toBe("collection-background");
+  });
+
+  it("sets a background image in the style attribute", function() {
+    expect(React.findDOMNode(render).getAttribute("style")).toContain("http://test.local/test.png");
+  });
+});

--- a/app/assets/javascripts/components/__tests__/other/Loading.spec.jsx
+++ b/app/assets/javascripts/components/__tests__/other/Loading.spec.jsx
@@ -9,13 +9,13 @@ describe('Loading', function() {
   var loading = TestUtils.renderIntoDocument(<Loading/>);
 
   it('returns a div with the className loading', function() {
-    expect(loading.getDOMNode().nodeName).toBe('DIV');
-    expect(loading.getDOMNode().className).toBe('loading');
+    expect(React.findDOMNode(loading).nodeName).toBe('DIV');
+    expect(React.findDOMNode(loading).className).toBe('loading');
   });
 
   it('has an img tag with src=images/ajax-loader.gif', function() {
-    expect(loading.getDOMNode().firstChild.nodeName).toBe('IMG');
-    expect(loading.getDOMNode().innerHTML).toContain('src="/images/ajax-loader.gif"');
+    expect(React.findDOMNode(loading).firstChild.nodeName).toBe('IMG');
+    expect(React.findDOMNode(loading).innerHTML).toContain('src="/images/ajax-loader.gif"');
   });
 
 });

--- a/app/assets/javascripts/components/__tests__/other/Thumbnail.spec.jsx
+++ b/app/assets/javascripts/components/__tests__/other/Thumbnail.spec.jsx
@@ -16,30 +16,30 @@ describe('Thumbnail', function() {
 
   it('renders /images/blank.png when no image is passed', function(){
     var thumbnail = TestUtils.renderIntoDocument(<Thumbnail/>);
-      expect(thumbnail.getDOMNode().nodeName).toBe('IMG');
-      expect(thumbnail.getDOMNode().src).toContain('/images/blank.png');
+      expect(React.findDOMNode(thumbnail).nodeName).toBe('IMG');
+      expect(React.findDOMNode(thumbnail).src).toContain('/images/blank.png');
   });
 
   it('renders the passed image in original format', function(){
     var thumbnail = TestUtils.renderIntoDocument(<Thumbnail image={image}/>);
-      expect(thumbnail.getDOMNode().nodeName).toBe('IMG');
-      expect(thumbnail.getDOMNode().src).toBe(image.contentUrl);
+      expect(React.findDOMNode(thumbnail).nodeName).toBe('IMG');
+      expect(React.findDOMNode(thumbnail).src).toBe(image.contentUrl);
   });
 
   it('renders the passed image in the medium format', function(){
     var thumbnail = TestUtils.renderIntoDocument(<Thumbnail image={image} thumbnailType="medium" />);
-      expect(thumbnail.getDOMNode().nodeName).toBe('IMG');
-      expect(thumbnail.getDOMNode().src).toBe(image['thumbnail/medium'].contentUrl);
+      expect(React.findDOMNode(thumbnail).nodeName).toBe('IMG');
+        expect(React.findDOMNode(thumbnail).src).toBe(image['thumbnail/medium'].contentUrl);
   });
 
   it('renders the the passed title', function(){
     var thumbnail = TestUtils.renderIntoDocument(<Thumbnail image={image} title="The title" />);
-      expect(thumbnail.getDOMNode().title).toBe("The title");
+      expect(React.findDOMNode(thumbnail).title).toBe("The title");
   });
 
   it('renders the the passed alt text', function(){
   var thumbnail = TestUtils.renderIntoDocument(<Thumbnail image={image} alt="<p>The <span>alt</span> text</p>" />);
-      expect(thumbnail.getDOMNode().alt).toBe("The alt text");
+      expect(React.findDOMNode(thumbnail).alt).toBe("The alt text");
   });
 
 

--- a/app/assets/javascripts/components/collection/CollectionBackground.jsx
+++ b/app/assets/javascripts/components/collection/CollectionBackground.jsx
@@ -1,4 +1,4 @@
-var React = require('react');
+var React = require("react");
 
 var CollectionBackground = React.createClass({
   propTypes: {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "gulp-watch": "^4.2.4",
     "jest-cli": "^0.4.12",
     "jquery": "^2.1.4",
-    "react": "^0.12.2",
+    "react": "^0.13.3",
     "react-scroll": "^0.18.0",
     "react-tools": "^0.12.2",
     "reactify": "^0.17.1"


### PR DESCRIPTION
What: Updated React to 13.3, updated current Jest tests, wrote one additional test.

Why: React has depreciated getDOMNode in the latest version and instead recommend using React.findDOMNode(). This affects Jest tests so since we're going to start pushing testing, let's make sure we do it with the latest version.
