### PR TITLE
Only run the React transformation  on jsx files

### DIFF
--- a/app/assets/javascripts/components/__tests__/preprocessor.js
+++ b/app/assets/javascripts/components/__tests__/preprocessor.js
@@ -1,9 +1,13 @@
 //app/assets/javascripts/components/__tests__/preprocessor.js
 var ReactTools = require('react-tools');
-
+var jsxPattern = /[.]jsx$/
 
 module.exports = {
-  process: function(src) {
-    return ReactTools.transform(src);
+  process: function(src, path) {
+    if (jsxPattern.test(path)) {
+      return ReactTools.transform(src);
+    } else {
+      return src;
+    }
   }
 };

--- a/app/assets/javascripts/components/__tests__/preprocessor.js
+++ b/app/assets/javascripts/components/__tests__/preprocessor.js
@@ -1,6 +1,6 @@
 //app/assets/javascripts/components/__tests__/preprocessor.js
 var ReactTools = require('react-tools');
-var jsxPattern = /[.]jsx$/
+var jsxPattern = /[.]jsx$/;
 
 module.exports = {
   process: function(src, path) {


### PR DESCRIPTION
Running the React transformation preprocessor on every javascript source (React, jQuery) is slow.  This changes the preprocessor to inspect the path and only run on *.jsx files.  In practice
 this cuts about 50-75% off of the time to run each test file.

**Before:**
![1____workspace_beehive__zsh_](https://cloud.githubusercontent.com/assets/127832/8231823/1daceeca-1599-11e5-886b-1e307428ebec.png)


**After:**
![1____workspace_beehive__zsh_](https://cloud.githubusercontent.com/assets/127832/8231803/05c9be96-1599-11e5-967e-6d732e2d908e.png)