### PR TITLE
Symlink node_modules directory on deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@ npm-debug.log
 /vendor/bundle/
 /public/assets/
 /coverage/
-/node-modules/
-
+/node_modules/

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,11 +27,9 @@ set :deploy_to, "/home/app/beehive"
 # set :linked_files, %w{config/database.yml}
 set :linked_files, %w{config/secrets.yml}
 
-set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets public/system vendor/bundle}
+set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets public/system vendor/bundle node_modules}
 
 set :default_env, { path: "/opt/ruby/current/bin:$PATH" }
-
-set :npm_flags, "--no-spin"
 
 namespace :deploy do
 
@@ -56,4 +54,5 @@ namespace :deploy do
 end
 
 after "deploy:finished", "airbrake:deploy"
-after "deploy:updated",     "newrelic:notice_deployment"
+after "deploy:updated", "newrelic:notice_deployment"
+before "npm:install", "npm:prune"

--- a/node_modules/.gitignore
+++ b/node_modules/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/package.json
+++ b/package.json
@@ -1,21 +1,24 @@
 {
   "name": "beehive",
+  "description": "Dependencies for the Beehive application",
   "repository": "git@github.com:ndlib/beehive.git",
-  "devDependencies": {
+  "dependencies": {
     "browserify": "^6.3.4",
     "browserify-incremental": "^1.5.0",
+    "react": "^0.13.3",
+    "react-scroll": "^0.18.0",
+    "reactify": "^0.17.1"
+  },
+  "devDependencies": {
     "coveralls": "^2.11.2",
     "gulp": "^3.9.0",
     "gulp-watch": "^4.2.4",
     "jest-cli": "^0.4.12",
     "jquery": "^2.1.4",
-    "react": "^0.13.3",
-    "react-scroll": "^0.18.0",
-    "react-tools": "^0.12.2",
-    "reactify": "^0.17.1"
+    "react-tools": "^0.12.2"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0 <0.12"
   },
   "scripts": {
     "test": "node ./node_modules/jest-cli/bin/jest.js"
@@ -39,8 +42,5 @@
     "testPathIgnorePatterns": [
       "preprocessor.js"
     ]
-  },
-  "dependencies": {
-    "coveralls": "^2.11.2"
   }
 }


### PR DESCRIPTION
Every time the application is deployed a fresh copy of the node modules are downloaded, which takes about 30 seconds.  Symlinking the node_modules directory cuts the time down to about 2 seconds if nothing has changed.