### PR TITLE
Guard npm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
   gem "guard", "~> 2.7.3"
   gem "guard-bundler"
   gem "guard-coffeescript"
+  gem "guard-npm"
   gem "guard-rails"
   gem "guard-rspec"
   gem "guard-spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: https://github.com/ndlib/hesburgh_infrastructure.git
-  revision: 2b9af6f2d5f2a588703d03cd1dd91c09e883f183
+  revision: 0b1301f74047aed18e9b3b553fabc607b9694529
   specs:
     hesburgh_infrastructure (0.2.5)
       rails

--- a/Guardfile
+++ b/Guardfile
@@ -22,3 +22,7 @@ end
 hesburgh_guard.rails do
   # Watch any custom paths
 end
+
+hesburgh_guard.npm do
+
+end


### PR DESCRIPTION
 * Adding `npm install` to guardfile with guard-npm.
 * Remember to run `bundle update hesburgh_infrastructure`