### PR TITLE
DEC-562 fix for intro card display bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,6 +388,3 @@ DEPENDENCIES
   thin
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.10.6

--- a/app/assets/javascripts/components/collection/CollectionShowShowcases.jsx
+++ b/app/assets/javascripts/components/collection/CollectionShowShowcases.jsx
@@ -7,9 +7,11 @@ var CollectionShowShowcases = React.createClass({
   },
 
   intro: function() {
-    return (
-      <CollectionIntroCard collection={this.props.collection} />
-    );
+    if (this.props.collection.description) {
+      return (
+        <CollectionIntroCard collection={this.props.collection} />
+      );
+    }
   },
 
   render: function() {


### PR DESCRIPTION
What: Fixed issue with intro card appearing when the intro text (collection description) had not been filled out, resulting in an error.
How: Added a conditional to the react component that checks for content in the collection description.