### PR TITLE
Facet sort

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -17,7 +17,7 @@ IEMixin = require("./mixins/IEMixin");
 GridListMixin = require("./mixins/GridListMixin");
 SearchMixin = require("./mixins/SearchMixin");
 DialogMixin = require("./mixins/DialogMixin");
-
+SearchUrlMixin = require("./mixins/SearchUrlMixin");
 
 // Layout
 Layout = require("./components/layout/Layout");
@@ -98,8 +98,9 @@ ItemsModalList = require("./components/item/ItemsModalList");
 
 // Search
 SearchDisplayList = require("./components/search/SearchDisplayList");
-SearchBox = require("./components/search/SearchBox")
-SearchSort = require("./components/search/SearchSort")
+SearchBox = require("./components/search/SearchBox");
+SearchSort = require("./components/search/SearchSort");
+SearchFacets = require("./components/search/SearchFacets")
 
 // Modal
 Modal = require("./components/modal/Modal");

--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -100,7 +100,8 @@ ItemsModalList = require("./components/item/ItemsModalList");
 SearchDisplayList = require("./components/search/SearchDisplayList");
 SearchBox = require("./components/search/SearchBox");
 SearchSort = require("./components/search/SearchSort");
-SearchFacets = require("./components/search/SearchFacets")
+SearchFacets = require("./components/search/SearchFacets");
+SearchPagination = require("./components/search/SearchPagination");
 
 // Modal
 Modal = require("./components/modal/Modal");

--- a/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
+++ b/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
@@ -15,7 +15,8 @@ var ItemsSearchPage = React.createClass({
       React.PropTypes.string,
       React.PropTypes.array,
     ]),
-    searchTerm: React.PropTypes.string
+    searchTerm: React.PropTypes.string,
+    sortTerm: React.PropTypes.string,
   },
 
   getInitialState: function() {
@@ -34,9 +35,11 @@ var ItemsSearchPage = React.createClass({
     } else {
       this.loadRemoteCollection(this.props.collection);
     }
-    this.loadSearchResults(
-      this.props.hits + "?q=" + encodeURIComponent(this.props.searchTerm)
-    );
+    var url = this.props.hits + "?q=" + encodeURIComponent(this.props.searchTerm);
+    if(this.props.sortTerm) {
+      url += "&sort=" + this.props.sortTerm;
+    }
+    this.loadSearchResults(url);
   },
 
   setValues: function(collection) {

--- a/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
+++ b/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
@@ -22,10 +22,12 @@ var ItemsSearchPage = React.createClass({
     return {
       collection: {},
       items: [],
+      sortOptions: [],
+      selectedIndex: 0,
     };
   },
 
-  componentDidMount: function() {
+  componentWillMount: function() {
     this.initSearchStore();
     if ('object' == typeof(this.props.collection)) {
       this.setValues(this.props.collection);
@@ -59,7 +61,9 @@ var ItemsSearchPage = React.createClass({
               collection={this.state.collection}
               items={this.state.items}
               facets={this.state.facets}
-              searchTerm={this.props.searchTerm} />
+              sortOptions={this.state.sortOptions}
+              searchTerm={this.props.searchTerm}
+              selectedIndex={this.state.selectedIndex} />
           </PageContent>
         </Layout>
         <CollectionOverlayFooter collection={this.state.collection} />

--- a/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
+++ b/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
@@ -2,7 +2,7 @@
 var React = require('react');
 
 var ItemsSearchPage = React.createClass({
-  mixins: [PageHeightMixin, LoadRemoteMixin, SearchMixin],
+  mixins: [SearchUrlMixin, PageHeightMixin, LoadRemoteMixin, SearchMixin],
 
   displayName: 'Items Search Page',
 
@@ -26,6 +26,7 @@ var ItemsSearchPage = React.createClass({
   },
 
   componentDidMount: function() {
+    this.initSearchStore();
     if ('object' == typeof(this.props.collection)) {
       this.setValues(this.props.collection);
     } else {
@@ -54,7 +55,11 @@ var ItemsSearchPage = React.createClass({
         <Layout>
 
           <PageContent>
-            <SearchDisplayList collection={this.state.collection} items={this.state.items} searchTerm={this.props.searchTerm} />
+            <SearchDisplayList
+              collection={this.state.collection}
+              items={this.state.items}
+              facets={this.state.facets}
+              searchTerm={this.props.searchTerm} />
           </PageContent>
         </Layout>
         <CollectionOverlayFooter collection={this.state.collection} />

--- a/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
+++ b/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
@@ -32,8 +32,7 @@ var ItemsSearchPage = React.createClass({
       this.loadRemoteCollection(this.props.collection);
     }
     this.loadSearchResults(
-      this.props.hits
-      + "?q=" + encodeURIComponent(his.props.searchTerm)
+      this.props.hits + "?q=" + encodeURIComponent(this.props.searchTerm)
     );
   },
 

--- a/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
+++ b/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
@@ -17,6 +17,7 @@ var ItemsSearchPage = React.createClass({
     ]),
     searchTerm: React.PropTypes.string,
     sortTerm: React.PropTypes.string,
+    facet: React.PropTypes.object,
   },
 
   getInitialState: function() {
@@ -36,6 +37,11 @@ var ItemsSearchPage = React.createClass({
       this.loadRemoteCollection(this.props.collection);
     }
     var url = this.props.hits + "?q=" + encodeURIComponent(this.props.searchTerm);
+    if(this.props.facet) {
+      var key = Object.keys(this.props.facet)[0];
+      var value = encodeURIComponent(this.props.facet[key]);
+      url += "&facets[" + key + "]=" + value;
+    }
     if(this.props.sortTerm) {
       url += "&sort=" + this.props.sortTerm;
     }
@@ -66,7 +72,8 @@ var ItemsSearchPage = React.createClass({
               facets={this.state.facets}
               sortOptions={this.state.sortOptions}
               searchTerm={this.props.searchTerm}
-              selectedIndex={this.state.selectedIndex} />
+              selectedIndex={this.state.selectedIndex}
+              selectedFacet={this.props.facet}/>
           </PageContent>
         </Layout>
         <CollectionOverlayFooter collection={this.state.collection} />

--- a/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
+++ b/app/assets/javascripts/components/pages/ItemsSearchPage.jsx
@@ -18,6 +18,13 @@ var ItemsSearchPage = React.createClass({
     searchTerm: React.PropTypes.string,
     sortTerm: React.PropTypes.string,
     facet: React.PropTypes.object,
+    start: React.PropTypes.number
+  },
+
+  getDefaultProps: function() {
+    return{
+      start: 0,
+    };
   },
 
   getInitialState: function() {
@@ -26,6 +33,8 @@ var ItemsSearchPage = React.createClass({
       items: [],
       sortOptions: [],
       selectedIndex: 0,
+      found: 0,
+      start: 0,
     };
   },
 
@@ -44,6 +53,9 @@ var ItemsSearchPage = React.createClass({
     }
     if(this.props.sortTerm) {
       url += "&sort=" + this.props.sortTerm;
+    }
+    if(this.props.start != 0) {
+      url += "&start=" + this.props.start;
     }
     this.loadSearchResults(url);
   },
@@ -73,7 +85,10 @@ var ItemsSearchPage = React.createClass({
               sortOptions={this.state.sortOptions}
               searchTerm={this.props.searchTerm}
               selectedIndex={this.state.selectedIndex}
-              selectedFacet={this.props.facet}/>
+              selectedFacet={this.props.facet}
+              found={this.state.found}
+              start={this.state.start}
+            />
           </PageContent>
         </Layout>
         <CollectionOverlayFooter collection={this.state.collection} />

--- a/app/assets/javascripts/components/search/SearchBox.jsx
+++ b/app/assets/javascripts/components/search/SearchBox.jsx
@@ -4,7 +4,7 @@ var mui = require('material-ui');
 var TextField = mui.TextField;
 
 var SearchBox = React.createClass({
-  mixins: [MuiThemeMixin],
+  mixins: [SearchUrlMixin, MuiThemeMixin],
   propTypes: {
     collection: React.PropTypes.object.isRequired,
     searchTerm: React.PropTypes.string,
@@ -24,16 +24,22 @@ var SearchBox = React.createClass({
   },
 
   onChange: function(e) {
-    this.setState({searchTerm: this.refs.searchBox.getValue()});
+    this.setTerm(this.refs.searchBox.getValue());
   },
 
   onClick: function(e) {
-    window.location.assign(this.searchUrl());
+    window.location.assign(this.searchUrl(this.props.collection));
   },
 
-  searchUrl: function() {
-    var url = window.location.origin + "/" + this.props.collection.id + "/" + this.props.collection.slug + "/search?q=" + encodeURIComponent(this.state.searchTerm);
-    return url;
+  componentDidMount: function() {
+    this.initSearchStore();
+    this.setTerm(this.refs.searchBox.getValue());
+  },
+
+  setTerm: function(term) {
+    var cleanTerm = '?q=' + encodeURIComponent(term);
+    window.searchStore.searchTerm = cleanTerm;
+    this.setState({searchTerm: cleanTerm});
   },
 
   render: function() {

--- a/app/assets/javascripts/components/search/SearchBox.jsx
+++ b/app/assets/javascripts/components/search/SearchBox.jsx
@@ -37,7 +37,7 @@ var SearchBox = React.createClass({
   },
 
   setTerm: function(term) {
-    var cleanTerm = '?q=' + encodeURIComponent(term);
+    var cleanTerm = encodeURIComponent(term);
     window.searchStore.searchTerm = cleanTerm;
     this.setState({searchTerm: cleanTerm});
   },

--- a/app/assets/javascripts/components/search/SearchDisplayList.jsx
+++ b/app/assets/javascripts/components/search/SearchDisplayList.jsx
@@ -13,6 +13,8 @@ var SearchDisplayList = React.createClass({
     sortOptions: React.PropTypes.array,
     selectedIndex: React.PropTypes.number,
     selectedFacet: React.PropTypes.object,
+    found: React.PropTypes.number,
+    start: React.PropTypes.number,
   },
 
   getDefaultProps: function() {
@@ -20,6 +22,8 @@ var SearchDisplayList = React.createClass({
       items: [],
       facets: [],
       searchTerm: "",
+      found: 0,
+      start: 0,
     };
   },
 
@@ -52,13 +56,22 @@ var SearchDisplayList = React.createClass({
             />
           </div>
           <div className="row-fluid col-lg-9">
-
+            <SearchPagination
+              collection={this.props.collection}
+              found={this.props.found}
+              start={this.props.start}
+            />
             <div className={this.listClass()}>
                 {itemNodes}
             </div>
+              <SearchPagination
+                collection={this.props.collection}
+                found={this.props.found}
+                start={this.props.start}
+              />
           </div>
         </div>
-         <div className='clearfix' />
+        <div className='clearfix' />
       </div>
     );
   }

--- a/app/assets/javascripts/components/search/SearchDisplayList.jsx
+++ b/app/assets/javascripts/components/search/SearchDisplayList.jsx
@@ -11,7 +11,8 @@ var SearchDisplayList = React.createClass({
     facets: React.PropTypes.array,
     searchTerm: React.PropTypes.string,
     sortOptions: React.PropTypes.array,
-    selectedIndex: React.PropTypes.number
+    selectedIndex: React.PropTypes.number,
+    selectedFacet: React.PropTypes.object,
   },
 
   getDefaultProps: function() {
@@ -44,7 +45,11 @@ var SearchDisplayList = React.createClass({
         <div className="row">
           {this.renderButtons(this.props.collection, this.props.searchTerm, this.props.sortOptions, this.props.selectedIndex)}
           <div className="row-fluid col-lg-3">
-            <SearchFacets collection={this.props.collection} facets={this.props.facets} />
+            <SearchFacets
+              collection={this.props.collection}
+              facets={this.props.facets}
+              selectedFacet={this.props.selectedFacet}
+            />
           </div>
           <div className="row-fluid col-lg-9">
 

--- a/app/assets/javascripts/components/search/SearchDisplayList.jsx
+++ b/app/assets/javascripts/components/search/SearchDisplayList.jsx
@@ -8,12 +8,14 @@ var SearchDisplayList = React.createClass({
   propTypes: {
     collection: React.PropTypes.object,
     items: React.PropTypes.array,
+    facets: React.PropTypes.array,
     searchTerm: React.PropTypes.string,
   },
 
   getDefaultProps: function() {
     return {
       items: [],
+      facets: [],
       searchTerm: "",
     };
   },
@@ -37,9 +39,17 @@ var SearchDisplayList = React.createClass({
     return (
       <div className='items-list' style={this.outerStyle()}>
         {this.displayItemWindow()}
-        {this.renderButtons(this.props.collection, this.props.searchTerm)}
-        <div className={this.listClass()}>
-          {itemNodes}
+        <div className="row">
+          {this.renderButtons(this.props.collection, this.props.searchTerm)}
+          <div className="row-fluid col-lg-3">
+            <SearchFacets collection={this.props.collection} facets={this.props.facets} />
+          </div>
+          <div className="row-fluid col-lg-9">
+
+            <div className={this.listClass()}>
+                {itemNodes}
+            </div>
+          </div>
         </div>
          <div className='clearfix' />
       </div>

--- a/app/assets/javascripts/components/search/SearchDisplayList.jsx
+++ b/app/assets/javascripts/components/search/SearchDisplayList.jsx
@@ -34,7 +34,24 @@ var SearchDisplayList = React.createClass({
     };
   },
 
-  render: function() {
+  facets: function()  {
+    if (this.props.facets.length > 0) {
+      return  (
+        <div className="row-fluid col-lg-3">
+          <SearchFacets
+            collection={this.props.collection}
+            facets={this.props.facets}
+            selectedFacet={this.props.selectedFacet}
+          />
+        </div>
+      );
+    }
+    else {
+      return null;
+    }
+  },
+
+  renderInner: function() {
     var view = this.state.view;
     var itemNodes = this.props.items.map(function(item, index) {
       var nodes = [];
@@ -43,33 +60,37 @@ var SearchDisplayList = React.createClass({
       ));
       return nodes;
     });
+
     return (
-      <div className='items-list' style={this.outerStyle()}>
-        {this.displayItemWindow()}
-        <div className="row">
-          {this.renderButtons(this.props.collection, this.props.searchTerm, this.props.sortOptions, this.props.selectedIndex)}
-          <div className="row-fluid col-lg-3">
-            <SearchFacets
-              collection={this.props.collection}
-              facets={this.props.facets}
-              selectedFacet={this.props.selectedFacet}
-            />
+      <div>
+        {this.facets()}
+        <div className={this.props.facets.length > 0 ? "row-fluid col-lg-9" : "row-fluid col-lg-12" }>
+          <SearchPagination
+            collection={this.props.collection}
+            found={this.props.found}
+            start={this.props.start}
+          />
+          <div className={this.listClass()}>
+              {itemNodes}
           </div>
-          <div className="row-fluid col-lg-9">
             <SearchPagination
               collection={this.props.collection}
               found={this.props.found}
               start={this.props.start}
             />
-            <div className={this.listClass()}>
-                {itemNodes}
-            </div>
-              <SearchPagination
-                collection={this.props.collection}
-                found={this.props.found}
-                start={this.props.start}
-              />
-          </div>
+        </div>
+      </div>
+    );
+  },
+
+  render: function() {
+
+    return (
+      <div className='items-list' style={this.outerStyle()}>
+        {this.displayItemWindow()}
+        <div className="row">
+          {this.renderButtons(this.props.collection, this.props.searchTerm, this.props.sortOptions, this.props.selectedIndex)}
+          {this.renderInner()}
         </div>
         <div className='clearfix' />
       </div>

--- a/app/assets/javascripts/components/search/SearchDisplayList.jsx
+++ b/app/assets/javascripts/components/search/SearchDisplayList.jsx
@@ -10,6 +10,8 @@ var SearchDisplayList = React.createClass({
     items: React.PropTypes.array,
     facets: React.PropTypes.array,
     searchTerm: React.PropTypes.string,
+    sortOptions: React.PropTypes.array,
+    selectedIndex: React.PropTypes.number
   },
 
   getDefaultProps: function() {
@@ -40,7 +42,7 @@ var SearchDisplayList = React.createClass({
       <div className='items-list' style={this.outerStyle()}>
         {this.displayItemWindow()}
         <div className="row">
-          {this.renderButtons(this.props.collection, this.props.searchTerm)}
+          {this.renderButtons(this.props.collection, this.props.searchTerm, this.props.sortOptions, this.props.selectedIndex)}
           <div className="row-fluid col-lg-3">
             <SearchFacets collection={this.props.collection} facets={this.props.facets} />
           </div>

--- a/app/assets/javascripts/components/search/SearchFacets.jsx
+++ b/app/assets/javascripts/components/search/SearchFacets.jsx
@@ -57,7 +57,7 @@ var SearchFacets = React.createClass({
     };
   },
 
-  componentDidMount: function() {
+  componentWillMount: function() {
     this.initSearchStore();
     window.searchStore.facetOption = {
       name: "",

--- a/app/assets/javascripts/components/search/SearchFacets.jsx
+++ b/app/assets/javascripts/components/search/SearchFacets.jsx
@@ -1,0 +1,77 @@
+'use strict'
+var React = require('react');
+var mui = require('material-ui');
+var List = mui.List;
+var ListItem = mui.ListItem;
+
+var SearchFacets = React.createClass({
+  mixins: [SearchUrlMixin],
+  propTypes: {
+    collection: React.PropTypes.object.isRequired,
+    facets: React.PropTypes.array,
+  },
+
+  facetList: function() {
+    return (
+      <List
+        ref='searchFacet'
+        subheader="Filter Search"
+        style={{backgroundColor: 'transparent'}}>
+        {this.facets()}
+      </List>
+    );
+  },
+
+  facets: function(){
+    self = this;
+    var facets = this.props.facets.map(function(e, index) {
+      var nodes = [];
+      nodes.push((
+        <ListItem primaryText={e.name} >
+          {self.values(e)}
+        </ListItem>
+      ));
+      return nodes;
+    });
+    return facets;
+  },
+
+  values: function(facet) {
+    var values;
+    if (facet.values) {
+      var values = facet.values.map(function(e, index) {
+        var nodes = [];
+        var value = encodeURIComponent(e.name);
+        nodes.push((
+          <ListItem
+            primaryText={e.name}
+            secondaryText={e.count}
+            value={value}
+          />
+        ));
+        return nodes;
+      });
+      return (
+        {values}
+      );
+    };
+  },
+
+  componentDidMount: function() {
+    this.initSearchStore();
+    window.searchStore.facetOption = {
+      name: "",
+      value: ""
+    };
+  },
+
+  render: function() {
+    return (
+      <div>
+        {this.facetList()}
+      </div>
+    );
+  }
+});
+
+module.exports = SearchFacets;

--- a/app/assets/javascripts/components/search/SearchFacets.jsx
+++ b/app/assets/javascripts/components/search/SearchFacets.jsx
@@ -27,7 +27,10 @@ var SearchFacets = React.createClass({
     var facets = this.props.facets.map(function(e, index) {
       var nodes = [];
       nodes.push((
-        <ListItem primaryText={e.name} >
+        <ListItem
+          primaryText={e.name}
+          open={true}
+        >
           {self.values(e)}
         </ListItem>
       ));

--- a/app/assets/javascripts/components/search/SearchFacets.jsx
+++ b/app/assets/javascripts/components/search/SearchFacets.jsx
@@ -22,6 +22,17 @@ var SearchFacets = React.createClass({
     );
   },
 
+  facetOnClick: function(e) {
+    console.log("FACET CLICK");
+    console.log(e.currentTarget.getAttribute("value"));
+  },
+
+  valueOnClick: function(parentFacet, e) {
+    window.searchStore.facetOption.name = parentFacet;
+    window.searchStore.facetOption.value = e.currentTarget.getAttribute("value");
+    window.location.assign(this.searchUrl(this.props.collection));
+  },
+
   facets: function(){
     self = this;
     var facets = this.props.facets.map(function(e, index) {
@@ -30,6 +41,8 @@ var SearchFacets = React.createClass({
         <ListItem
           primaryText={e.name}
           open={true}
+          onClick={self.facetOnClick}
+          value={encodeURIComponent(e.field)}
         >
           {self.values(e)}
         </ListItem>
@@ -40,6 +53,8 @@ var SearchFacets = React.createClass({
   },
 
   values: function(facet) {
+    self = this;
+    var parentFacet = facet.field;
     var values;
     if (facet.values) {
       var values = facet.values.map(function(e, index) {
@@ -50,6 +65,7 @@ var SearchFacets = React.createClass({
             primaryText={e.name}
             secondaryText={e.count}
             value={value}
+            onClick={self.valueOnClick.bind(this, parentFacet)}
           />
         ));
         return nodes;

--- a/app/assets/javascripts/components/search/SearchFacets.jsx
+++ b/app/assets/javascripts/components/search/SearchFacets.jsx
@@ -24,8 +24,7 @@ var SearchFacets = React.createClass({
   },
 
   facetOnClick: function(e) {
-    console.log("FACET CLICK");
-    console.log(e.currentTarget.getAttribute("value"));
+    e.currentTarget.getAttribute("value");
   },
 
   valueOnClick: function(parentFacet, e) {

--- a/app/assets/javascripts/components/search/SearchFacets.jsx
+++ b/app/assets/javascripts/components/search/SearchFacets.jsx
@@ -9,6 +9,7 @@ var SearchFacets = React.createClass({
   propTypes: {
     collection: React.PropTypes.object.isRequired,
     facets: React.PropTypes.array,
+    selectedFacet: React.PropTypes.object,
   },
 
   facetList: function() {
@@ -28,6 +29,7 @@ var SearchFacets = React.createClass({
   },
 
   valueOnClick: function(parentFacet, e) {
+    window.searchStore.facetOption = {}
     window.searchStore.facetOption.name = parentFacet;
     window.searchStore.facetOption.value = e.currentTarget.getAttribute("value");
     window.location.assign(this.searchUrl(this.props.collection));
@@ -78,10 +80,14 @@ var SearchFacets = React.createClass({
 
   componentWillMount: function() {
     this.initSearchStore();
-    window.searchStore.facetOption = {
-      name: "",
-      value: ""
-    };
+    if(this.props.selectedFacet){
+      var key = Object.keys(this.props.selectedFacet)[0];
+      var value = encodeURIComponent(this.props.selectedFacet[key]);
+      window.searchStore.facetOption = {
+        name: key,
+        value: value,
+      };
+    }
   },
 
   render: function() {

--- a/app/assets/javascripts/components/search/SearchPagination.jsx
+++ b/app/assets/javascripts/components/search/SearchPagination.jsx
@@ -1,0 +1,77 @@
+'use strict'
+var React = require('react');
+var mui = require('material-ui');
+
+var SearchPagination = React.createClass({
+  mixins: [SearchUrlMixin],
+  propTypes: {
+    collection: React.PropTypes.object.isRequired,
+    found: React.PropTypes.number,
+    start: React.PropTypes.number,
+    count: React.PropTypes.number,
+  },
+
+  getDefaultProps: function() {
+    return {
+      found: 0,
+      start: 0,
+      count: 10,
+    };
+  },
+
+  pageLink: function(i) {
+    if(this.props.start === (i-1) * this.props.count){
+      return(
+        <span> {i} </span>
+      );
+    }
+    else {
+      var searchUrl = this.searchUrl(this.props.collection) + '&start=' + (i-1)*this.props.count;
+      return(
+        <a href={searchUrl}> {i} </a>
+      );
+    }
+  },
+
+  pageLinks: function() {
+    var nodes = [];
+    // if not first page
+    if(this.props.start != 0) {
+      var backLink = this.searchUrl(this.props.collection) + '&start=' + (this.props.start - this.props.count);
+      nodes.push((<a href={backLink}> <i className='mdi-navigation-arrow-back' style={{fontSize: '20px'}}/> </a>));
+    }
+    if(this.props.found > this.props.count){
+      var last = this.props.found/this.props.count;
+      if(this.props.found%this.props.count != 0){
+        last += 1;
+      }
+      for (var i = 1; i <= last; i++) {
+        nodes.push(this.pageLink(i));
+      }
+    }
+    // if not last page
+    if(this.props.start + this.props.count < this.props.found) {
+      var forwardLink = this.searchUrl(this.props.collection) + '&start=' + (this.props.start + this.props.count);
+      nodes.push((<a href={forwardLink}> <i className='mdi-navigation-arrow-forward' style={{fontSize: '20px'}}/> </a>));
+    }
+    return nodes;
+  },
+
+  render: function() {
+    // people think of the first record as 1, not 0.
+    var startHuman = this.props.start + 1;
+    var endHuman = Math.min(this.props.start + this.props.count, this.props.found);
+    return (
+      <div>
+        <div className='clearfix' />
+        <div style={{color:'black', fontSize: '20px', float: 'right', textAlign: 'right'}}>
+          <div>Showing {startHuman} - {endHuman} of {this.props.found}</div>
+          {this.pageLinks()}
+        </div>
+        <div className='clearfix' />
+      </div>
+    );
+  }
+});
+
+module.exports = SearchPagination;

--- a/app/assets/javascripts/components/search/SearchSort.jsx
+++ b/app/assets/javascripts/components/search/SearchSort.jsx
@@ -50,7 +50,6 @@ var SearchSort = React.createClass({
   },
 
   render: function() {
-    console.log(this.props.selectedIndex);
     return(
       <SelectField
         value={null}

--- a/app/assets/javascripts/components/search/SearchSort.jsx
+++ b/app/assets/javascripts/components/search/SearchSort.jsx
@@ -4,6 +4,7 @@ var mui = require('material-ui');
 var SelectField = mui.SelectField;
 var MenuItem = mui.MenuItem;
 var SearchSort = React.createClass({
+  mixins: [SearchUrlMixin],
 
   propTypes: {
     collection: React.PropTypes.object.isRequired,
@@ -13,8 +14,8 @@ var SearchSort = React.createClass({
   getDefaultProps: function() {
     return {
       sortOptions: [
-        {text: 'Item Name', payload: 'name', direction: 'dsc'},
-        {text: 'Creator', payload: 'creator', direction: 'asc'}
+        {text: 'Item Name', value: 'dsc'},
+        {text: 'Creator', value: 'asc'}
       ]
     };
   },
@@ -26,25 +27,28 @@ var SearchSort = React.createClass({
     return state;
   },
 
-  searchUrl: function(sort) {
-    var searchTerm = "/search" + window.location.search.split('&', 1);
-    var sortTerm = "&sort=[]" +sort.payload + " " + sort.direction;
-    var url = window.location.origin + "/" +this.props.collection.id + "/" + this.props.collection.slug + encodeURIComponent(searchTerm) + encodeURIComponent(sortTerm);
-    return url;
-  },
-
   onChange: function(prop, e) {
     var change = {};
     change[prop] = e.target.value;
-    window.location.assign(this.searchUrl(change.selectValue));
+    this.setSort(change.selectValue.value);
+    window.location.assign(this.searchUrl(this.props.collection));
+  },
+
+  setSort: function(sortOption) {
+    window.searchStore.sortOption = sortOption;
     this.setState({hintText: ''});
+  },
+
+  componentDidMount: function() {
+    this.initSearchStore();
+    this.setSort('');
   },
 
   render: function() {
     return(
       <SelectField
         value={null}
-        ref='sortType'
+        ref='searchSort'
         hintText={this.state.hintText}
         onChange={this.onChange.bind(null, 'selectValue')}
         menuItems={this.props.sortOptions}

--- a/app/assets/javascripts/components/search/SearchSort.jsx
+++ b/app/assets/javascripts/components/search/SearchSort.jsx
@@ -8,51 +8,59 @@ var SearchSort = React.createClass({
 
   propTypes: {
     collection: React.PropTypes.object.isRequired,
-    sortOptions: React.PropTypes.array
-  },
-
-  getDefaultProps: function() {
-    return {
-      sortOptions: [
-        {text: 'Item Name', value: 'dsc'},
-        {text: 'Creator', value: 'asc'}
-      ]
-    };
+    sortOptions: React.PropTypes.array,
+    selectedIndex: React.PropTypes.number,
   },
 
   getInitialState: function() {
     var state = {
-      hintText: 'Sort Results',
+      selectValue: 0,
     }
     return state;
   },
 
+  getDefaultProps: function() {
+    return {
+      sortOptions: [],
+      selectedIndex: -1,
+    };
+  },
+
   onChange: function(prop, e) {
-    var change = {};
-    change[prop] = e.target.value;
-    this.setSort(change.selectValue.value);
+    this.setSort(e.target.value);
     window.location.assign(this.searchUrl(this.props.collection));
   },
 
   setSort: function(sortOption) {
     window.searchStore.sortOption = sortOption;
-    this.setState({hintText: ''});
   },
 
-  componentDidMount: function() {
+  componentWillMount: function() {
     this.initSearchStore();
-    this.setSort('');
+    var regex = /\S+&sort=/;
+    var sortOption = '';
+    if(window.location.search.match(regex)) {
+      sortOption = window.location.search.replace(regex, '');
+    }
+    this.setSort(sortOption);
+  },
+
+  shouldComponentUpdate: function(nextProps, nextState) {
+    return(nextProps.selectedIndex !== this.props.selectedIndex);
   },
 
   render: function() {
+    console.log(this.props.selectedIndex);
     return(
       <SelectField
         value={null}
         ref='searchSort'
-        hintText={this.state.hintText}
-        onChange={this.onChange.bind(null, 'selectValue')}
+        onChange={this.onChange.bind(this, 'selectValue')}
         menuItems={this.props.sortOptions}
         style={{float:'right', marginLeft: '2em'}}
+        selectedIndex={this.props.selectedIndex}
+        displayMember='name'
+        valueMember='value'
       />
     );
   }

--- a/app/assets/javascripts/components/search/SearchSort.jsx
+++ b/app/assets/javascripts/components/search/SearchSort.jsx
@@ -52,7 +52,6 @@ var SearchSort = React.createClass({
   render: function() {
     return(
       <SelectField
-        value={null}
         ref='searchSort'
         onChange={this.onChange.bind(this, 'selectValue')}
         menuItems={this.props.sortOptions}

--- a/app/assets/javascripts/components/search/SearchSort.jsx
+++ b/app/assets/javascripts/components/search/SearchSort.jsx
@@ -40,7 +40,7 @@ var SearchSort = React.createClass({
     var regex = /\S+&sort=/;
     var sortOption = '';
     if(window.location.search.match(regex)) {
-      sortOption = window.location.search.replace(regex, '');
+      sortOption = window.location.search.replace(regex, '').split('&')[0];
     }
     this.setSort(sortOption);
   },

--- a/app/assets/javascripts/components/search/SearchSort.jsx
+++ b/app/assets/javascripts/components/search/SearchSort.jsx
@@ -50,17 +50,22 @@ var SearchSort = React.createClass({
   },
 
   render: function() {
-    return(
-      <SelectField
-        ref='searchSort'
-        onChange={this.onChange.bind(this, 'selectValue')}
-        menuItems={this.props.sortOptions}
-        style={{float:'right', marginLeft: '2em'}}
-        selectedIndex={this.props.selectedIndex}
-        displayMember='name'
-        valueMember='value'
-      />
-    );
+    if(this.props.sortOptions.length > 0) {
+      return(
+        <SelectField
+          ref='searchSort'
+          onChange={this.onChange.bind(this, 'selectValue')}
+          menuItems={this.props.sortOptions}
+          style={{float:'right', marginLeft: '2em'}}
+          selectedIndex={this.props.selectedIndex}
+          displayMember='name'
+          valueMember='value'
+        />
+      );
+    }
+    else {
+      return null;
+    }
   }
 });
 module.exports = SearchSort

--- a/app/assets/javascripts/mixins/GridListMixin.jsx
+++ b/app/assets/javascripts/mixins/GridListMixin.jsx
@@ -66,25 +66,30 @@ var GridListMixin = {
     return (
 
       <div className="controls" style={this.controlsStyle()}>
-        <div className="pull-left">
-          <SearchBox collection={collection} searchTerm={searchTerm}/>
+        <div className="col-lg-3" />
+        <div className="col-lg-9" >
+          <div className="pull-left">
+            <SearchBox collection={collection} searchTerm={searchTerm}/>
+            <SearchSort collection={collection} />
+          </div>
+          <button
+            className={listClass}
+            onClick={this.setList}
+            style={{zIndex: '0'}}
+          >
+            <i className="mdi-action-view-list"></i>
+            List
+          </button>
+          <button
+            className={gridClass}
+            onClick={this.setGrid}
+            style={{zIndex: '0'}}
+          >
+            <i className= "mdi-action-view-module"></i>
+            Grid
+          </button>
+          <div className="clearfix" />
         </div>
-        <button
-          className={listClass}
-          onClick={this.setList}
-          style={{zIndex: '0'}}
-        >
-          <i className="mdi-action-view-list"></i>
-          List
-        </button>
-        <button
-          className={gridClass}
-          onClick={this.setGrid}
-          style={{zIndex: '0'}}
-        >
-          <i className= "mdi-action-view-module"></i>
-          Grid
-        </button>
         <div className="clearfix" />
       </div>
     );

--- a/app/assets/javascripts/mixins/GridListMixin.jsx
+++ b/app/assets/javascripts/mixins/GridListMixin.jsx
@@ -47,7 +47,7 @@ var GridListMixin = {
     return this.state.view;
   },
 
-  renderButtons: function(collection, searchTerm) {
+  renderButtons: function(collection, searchTerm, sortOptions, selectedIndex) {
     var classNames = require('classnames');
     var gridClass = classNames(
       'btn',
@@ -63,14 +63,17 @@ var GridListMixin = {
       'btn-view',
       'pull-right'
     );
+    var searchSort;
+    if(this.props.sortOptions.length > 1) {
+      searchSort = (<SearchSort collection={collection} sortOptions={sortOptions} selectedIndex={selectedIndex}/>);
+    }
     return (
-
       <div className="controls" style={this.controlsStyle()}>
         <div className="col-lg-3" />
         <div className="col-lg-9" >
           <div className="pull-left">
             <SearchBox collection={collection} searchTerm={searchTerm}/>
-            <SearchSort collection={collection} />
+            {searchSort}
           </div>
           <button
             className={listClass}

--- a/app/assets/javascripts/mixins/SearchMixin.jsx
+++ b/app/assets/javascripts/mixins/SearchMixin.jsx
@@ -10,7 +10,7 @@ var searchMixin = {
       success: function(result) {
         this.setItems(result.hits);
         this.setFacets(result.facets);
-        this.setSort(result.sorts)
+        this.setSorts(result.sorts)
       },
       error: function(request, status, thrownError) {
           window.location = window.location.origin + '/404';
@@ -34,8 +34,17 @@ var searchMixin = {
     });
   },
 
-  setSort: function(sorts) {
-    console.log(sorts);
+  setSorts: function(sorts) {
+    var regex = /\S+&sort=/;
+    var sortOption = '';
+    if(window.location.search.match(regex)) {
+      sortOption = window.location.search.replace(regex, '');
+    };
+
+    this.setState({
+      sortOptions: sorts,
+      selectedIndex: sorts.map(function(s) {return s.value; }).indexOf(sortOption),
+    });
   },
 
   mapHitToItem: function(hit) {

--- a/app/assets/javascripts/mixins/SearchMixin.jsx
+++ b/app/assets/javascripts/mixins/SearchMixin.jsx
@@ -24,6 +24,8 @@ var searchMixin = {
 
   setItems: function(hits) {
     var items = [];
+    var found = hits.found;
+    var start = hits.start;
     for (var h in hits.hit) {
       var hit = hits.hit[h];
       var item = this.mapHitToItem(hit);
@@ -31,6 +33,8 @@ var searchMixin = {
     }
     this.setState({
       items: items,
+      found: found,
+      start: start,
     });
   },
 

--- a/app/assets/javascripts/mixins/SearchMixin.jsx
+++ b/app/assets/javascripts/mixins/SearchMixin.jsx
@@ -9,11 +9,17 @@ var searchMixin = {
       dataType: "json",
       success: function(result) {
         this.setItems(result.hits);
+        this.setFacets(result.facets);
+        this.setSort(result.sorts)
       },
       error: function(request, status, thrownError) {
           window.location = window.location.origin + '/404';
       }
     });
+  },
+
+  setFacets: function(facets) {
+    this.setState({facets: facets});
   },
 
   setItems: function(hits) {
@@ -26,6 +32,10 @@ var searchMixin = {
     this.setState({
       items: items,
     });
+  },
+
+  setSort: function(sorts) {
+    console.log(sorts);
   },
 
   mapHitToItem: function(hit) {

--- a/app/assets/javascripts/mixins/SearchUrlMixin.jsx
+++ b/app/assets/javascripts/mixins/SearchUrlMixin.jsx
@@ -18,7 +18,7 @@ var SearchUrlMixin = {
     if(window.searchStore.sortOption) {
       url += "&sort=" + window.searchStore.sortOption;
     }
-    + "&sort=" + window.searchStore.sortOption
+    + "&sort=" + window.searchStore.sortOption;
     return url;
   },
 }

--- a/app/assets/javascripts/mixins/SearchUrlMixin.jsx
+++ b/app/assets/javascripts/mixins/SearchUrlMixin.jsx
@@ -1,0 +1,23 @@
+var SearchUrlMixin = {
+  initSearchStore: function() {
+    if(!window.searchStore) {
+      window.searchStore = {};
+    }
+  },
+
+  searchUrl: function(collection) {
+    var url = window.location.origin
+      + "/" + collection.id
+      + "/" + collection.slug
+      + "/search" + window.searchStore.searchTerm;
+    if(window.searchStore.facetOption) {
+      url += "&facet[" + window.searchStore.facetOption.name + "]=" + window.searchStore.facetOption.value;
+    }
+    if(window.searchStore.sortOption) {
+      url += "&sort=" + window.searchStore.sortOption;
+    }
+    + "&sort=" + window.searchStore.sortOption
+    return url;
+  },
+}
+module.exports = SearchUrlMixin;

--- a/app/assets/javascripts/mixins/SearchUrlMixin.jsx
+++ b/app/assets/javascripts/mixins/SearchUrlMixin.jsx
@@ -9,9 +9,11 @@ var SearchUrlMixin = {
     var url = window.location.origin
       + "/" + collection.id
       + "/" + collection.slug
-      + "/search" + window.searchStore.searchTerm;
+      + "/search?q=" + window.searchStore.searchTerm;
     if(window.searchStore.facetOption) {
-      url += "&facet[" + window.searchStore.facetOption.name + "]=" + window.searchStore.facetOption.value;
+      if(window.searchStore.facetOption.name) {
+        url += "&facet[" + window.searchStore.facetOption.name + "]=" + window.searchStore.facetOption.value;
+      }
     }
     if(window.searchStore.sortOption) {
       url += "&sort=" + window.searchStore.sortOption;

--- a/app/views/items/search.erb
+++ b/app/views/items/search.erb
@@ -1,1 +1,1 @@
-<%= react_component('ItemsSearchPage', {collection: @collections_url, hits: @hit_url, searchTerm: params[:q], sortTerm: params[:sort]}) %>
+<%= react_component('ItemsSearchPage', {collection: @collections_url, hits: @hit_url, searchTerm: params[:q], sortTerm: params[:sort], facet: params[:facet]}) %>

--- a/app/views/items/search.erb
+++ b/app/views/items/search.erb
@@ -1,1 +1,1 @@
-<%= react_component('ItemsSearchPage', {collection: @collections_url, hits: @hit_url, searchTerm: params[:q], sortTerm: params[:sort], facet: params[:facet]}) %>
+<%= react_component('ItemsSearchPage', {collection: @collections_url, hits: @hit_url, searchTerm: params[:q], sortTerm: params[:sort], facet: params[:facet]}, start: params[:start]) %>

--- a/app/views/items/search.erb
+++ b/app/views/items/search.erb
@@ -1,1 +1,1 @@
-<%= react_component('ItemsSearchPage', {collection: @collections_url, hits: @hit_url, searchTerm: params[:q]}) %>
+<%= react_component('ItemsSearchPage', {collection: @collections_url, hits: @hit_url, searchTerm: params[:q], sortTerm: params[:sort]}) %>

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "beehive",
   "description": "Dependencies for the Beehive application",
@@ -10,7 +11,7 @@
     "flux": "^2.0.3",
     "jquery": "^2.1.4",
     "keymirror": "^0.1.1",
-    "material-ui": "^0.10.1",
+    "material-ui": "0.10.2",
     "object-assign": "^3.0.0",
     "react": "^0.13.3",
     "react-scroll": "^0.18.0",


### PR DESCRIPTION
*** Note: requires search-facets-stub branch of Honeycomb ***

* I created separate react components for each of the main widgets: searchbox, facets, sort dropdown.
* Create search box widget that can be displayed on any page.
* Create sort and facets widgets based on JSON data returned from ajax request. Only show them if they are returned.
* Pass the search page's url's query strings back to the ajax search request.


