### PR TITLE
Fix Firefox performance on image zoom component.

### DIFF
--- a/app/assets/javascripts/components/pages/ShowcaseShowPage.jsx
+++ b/app/assets/javascripts/components/pages/ShowcaseShowPage.jsx
@@ -30,7 +30,6 @@ var ShowcaseShowPage = React.createClass({
       return (
         <SectionsModalList height={this.state.height} sections={this.state.showcase.sections} />
       );
-      return (<span />);
     }
     else {
       return (<span />);

--- a/app/assets/javascripts/components/showcase/ShowcaseShow.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseShow.jsx
@@ -107,11 +107,15 @@ var ShowcaseShow = React.createClass({
     var percentVisible = 1 - scrollLeft/titleWidth;
     if (percentVisible < 0) {
       percentVisible = 0;
+    } else {
+      percentVisible = Math.round(percentVisible * 100) / 100;
     }
-    this.setState({
-      scrollOffsetLeft: scrollLeft,
-      titleSectionPercentVisible: percentVisible,
-    });
+    if (scrollLeft != this.state.scrollOffsetLeft || percentVisible != this.state.titleSectionPercentVisible) {
+      this.setState({
+        scrollOffsetLeft: scrollLeft,
+        titleSectionPercentVisible: percentVisible,
+      });
+    }
   },
 
   render: function() {


### PR DESCRIPTION
There was an issue in Firefox where openseadragon was triggering a lot of scroll events on the ShowcaseShow component, which would cause the component to rerender.

This changes the onScroll function to only change the state when the values actually change.