### PR TITLE
Showcase performance improvements

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -66,6 +66,7 @@ CollectionBackground = require("./components/collection/CollectionBackground");
 // Showcases
 ShowcasesCardList = require("./components/showcase/ShowcasesCardList");
 ShowcaseShow = require("./components/showcase/ShowcaseShow");
+ShowcaseInnerContent = require("./components/showcase/ShowcaseInnerContent");
 ShowcaseSections = require("./components/showcase/ShowcaseSections");
 ShowcaseTitle = require("./components/showcase/ShowcaseTitle");
 ShowcaseTitleBar = require("./components/showcase/ShowcaseTitleBar");

--- a/app/assets/javascripts/components/other/AttentionHelp.jsx
+++ b/app/assets/javascripts/components/other/AttentionHelp.jsx
@@ -20,7 +20,6 @@ var AttentionHelp = React.createClass({
 
   componentDidMount: function() {
     this.timer = setInterval(this.tick, 1000);
-
   },
 
   componentWillUnmount: function() {
@@ -41,11 +40,11 @@ var AttentionHelp = React.createClass({
     var elapsed = Math.round(this.state.elapsed / 1000);
     // we'll load it before we want to play it so there isn't a delay
     var snackbar = (<source src="/attention.mp3" type="audio/mpeg"/>);
-    var audioPlay = ""
-    var storage = JSON.parse(sessionStorage.getItem("AudioPlayed"));
 
     if(!this.props.hasScrolled && elapsed >= 5 && elapsed <= 15) {
-    if(!storage) {
+      var audioPlay;
+      var storage = JSON.parse(sessionStorage.getItem("AudioPlayed"));
+      if(!storage) {
         audioPlay = (
           <audio autoPlay>
             <source src="/attention.mp3" type="audio/mpeg"/>

--- a/app/assets/javascripts/components/other/Scroller.jsx
+++ b/app/assets/javascripts/components/other/Scroller.jsx
@@ -5,9 +5,21 @@ var Scroller = React.createClass({
     target: React.PropTypes.string.isRequired,
   },
 
+  getInitialState: function() {
+    return {
+      element: null,
+    };
+  },
+
   onMouseDown: function(direction, event) {
-    var scrollDelta = Math.ceil($(this.props.target).get(0).clientWidth * (3/4));
-    $(this.props.target).animate({scrollLeft: ($(this.props.target).get(0).scrollLeft + scrollDelta * direction)}, 500);
+    var scrollDelta = Math.ceil(this.state.element.clientWidth * (3/4));
+    $(this.state.element).animate({scrollLeft: (this.state.element.scrollLeft + scrollDelta * direction)}, 500);
+  },
+
+  componentDidMount: function() {
+    this.setState({
+      element: $(this.props.target).get(0),
+    });
   },
 
   style: function() {
@@ -24,15 +36,15 @@ var Scroller = React.createClass({
   },
 
   maxScroll: function() {
-    return $(this.props.target).get(0).scrollWidth - $(this.props.target).get(0).clientWidth;
+    return this.state.element.scrollWidth - this.state.element.clientWidth;
   },
 
   render: function() {
-    var left = "";
-    var right = "";
+    var left;
+    var right;
 
-    if($(this.props.target).get(0)) {
-      if($(this.props.target).get(0).scrollLeft > 0) {
+    if(this.state.element) {
+      if(this.state.element.scrollLeft > 0) {
         left = (
           <div className="scroll-left" onMouseDown={this.onMouseDown.bind(this, -1)} style={this.style()}>
             <i className="scroll-arrow mdi-navigation-chevron-left" style={this.iconStyle()}/>
@@ -40,15 +52,15 @@ var Scroller = React.createClass({
         );
       }
 
-      if($(this.props.target).get(0).scrollLeft < this.maxScroll() - 10) {
+      if(this.state.element.scrollLeft < this.maxScroll() - 10) {
         right = (
-        <div className="scroll-right" onMouseDown={this.onMouseDown.bind(this, 1)} style={this.style()}>
+          <div className="scroll-right" onMouseDown={this.onMouseDown.bind(this, 1)} style={this.style()}>
             <i className="scroll-arrow mdi-navigation-chevron-right" style={this.iconStyle()}/>
           </div>
         );
       }
     }
-    return(
+    return (
       <div>
         {left}
         {right}

--- a/app/assets/javascripts/components/showcase/ShowcaseInnerContent.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseInnerContent.jsx
@@ -1,0 +1,37 @@
+//app/assets/javascripts/components/showcase/ShowcaseInnerContent.jsx
+var React = require("react");
+
+var ShowcaseInnerContent = React.createClass({
+  propTypes: {
+    showcase: React.PropTypes.object,
+    height: React.PropTypes.number.isRequired,
+  },
+
+  style: function() {
+    return {
+      position: "absolute",
+      height: this.props.height + "px",
+      top: 0,
+      left: 0,
+      overflowX: "visible",
+      overflowY: "visible",
+      paddingTop: "20px",
+    };
+  },
+
+  shouldComponentUpdate: function(nextProps, nextState) {
+    return JSON.stringify(this.props) !== JSON.stringify(nextProps);
+  },
+
+  render: function() {
+    return (
+      <div id="showcase-inner" className="showcase-inner" style={this.style()} >
+        <ShowcaseTitle height={this.props.height} showcase={this.props.showcase} />
+        <ShowcaseSections height={this.props.height} showcase={this.props.showcase} />
+      </div>
+    );
+  }
+});
+
+// each file will export exactly one component
+module.exports = ShowcaseInnerContent;

--- a/app/assets/javascripts/components/showcase/ShowcaseShow.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseShow.jsx
@@ -18,7 +18,6 @@ var ShowcaseShow = React.createClass({
 
   getInitialState: function() {
     return {
-      scrollOffsetLeft: 0,
       titleSectionPercentVisible: 1,
       startTime: Date.now(),
       hasScrolled: false,
@@ -71,18 +70,6 @@ var ShowcaseShow = React.createClass({
     }
   },
 
-  styleInner: function(height) {
-    return {
-      position: "absolute",
-      height: height + "px",
-      top: 0,
-      left: 0,
-      overflowX: "visible",
-      overflowY: "visible",
-      paddingTop: "20px",
-    };
-  },
-
   styleOuter: function(height) {
     return {
       position: "relative",
@@ -110,9 +97,8 @@ var ShowcaseShow = React.createClass({
     } else {
       percentVisible = Math.round(percentVisible * 100) / 100;
     }
-    if (scrollLeft != this.state.scrollOffsetLeft || percentVisible != this.state.titleSectionPercentVisible) {
+    if (percentVisible != this.state.titleSectionPercentVisible) {
       this.setState({
-        scrollOffsetLeft: scrollLeft,
         titleSectionPercentVisible: percentVisible,
       });
     }
@@ -138,17 +124,12 @@ var ShowcaseShow = React.createClass({
           <ShowcaseTitleBar percentFade={this.state.titleSectionPercentVisible} height={showcaseTitleHeight} showcase={this.props.showcase} />
           <div id="showcase-outer" className="showcase-outer" style={this.styleOuter(showcaseHeight)} onScroll={this.onScroll}>
             <Scroller target="#showcase-outer" />
-            <div id="showcase-inner" className="showcase-inner" style={this.styleInner(showcaseInnerHeight)} >
-              <ShowcaseTitle height={showcaseInnerHeight} showcase={this.props.showcase} />
-              <ShowcaseSections height={showcaseInnerHeight} showcase={this.props.showcase} />
-
-            </div>
+            <ShowcaseInnerContent height={showcaseInnerHeight} showcase={this.props.showcase} />
           </div>
         </div>
-
-      )
+      );
     } else {
-      return (<Loading />)
+      return (<Loading />);
     }
   }
 });


### PR DESCRIPTION
This implements a number of changes to improve showcase performance:
1. Remove the scrollOffsetLeft state variable from ShowcaseShow. This was triggering a rerender on ShowcaseShow and all child components every time the scroll offset changed by even a single pixel.
2. Moved the showcase inner content into a new separate component.  This component implements shouldComponentUpdate, and will only render if the props have changed.
3. Tweaked the logic in AttentionHelp component to avoid building variables that aren't used. (Probably not a noticeable improvement)
4. In the Scroller component, store the target element in the state so it doesn't have to be found repeatedly via jQuery.

I noticed some improvements on my laptop, but we'll need to test this on smaller devices to really discern how much of a difference it made.