### PR TITLE
Showcase slide animation + scrolling

### DIFF
--- a/app/assets/javascripts/components/modal/Modal.jsx
+++ b/app/assets/javascripts/components/modal/Modal.jsx
@@ -13,6 +13,27 @@ var Modal = React.createClass({
     title: React.PropTypes.string,
   },
 
+  getInitialState: function() {
+    return {
+      rendered: false,
+      element: null,
+    }
+  },
+
+  componentDidMount: function() {
+    var element = $(React.findDOMNode(this));
+    this.setState({
+      element: element,
+    });
+    element.on('show.bs.modal', this.setRendered);
+  },
+
+  setRendered: function() {
+    this.setState({
+      rendered: true,
+    });
+  },
+
   styles: function() {
     if (this.props.height) {
       return {
@@ -54,6 +75,12 @@ var Modal = React.createClass({
     }
   },
 
+  content: function() {
+    if (this.state.rendered) {
+      return this.props.content;
+    }
+  },
+
   render: function () {
     return (
       <div className={this.className()} id={this.props.id} tabIndex="-1" data-backdrop="static"  onKeyDown={this.onKeyDown} style={this.outerStyle()}>
@@ -63,7 +90,7 @@ var Modal = React.createClass({
               <button type="button" className="close" data-dismiss="modal" aria-label="Close" onClick={this.removeHash}><i className="mdi-content-clear"></i></button>
                 <h4 className="modal-title">{this.props.title}</h4>
             </div>
-            <div className="modal-body">{this.props.content}</div>
+            <div className="modal-body">{this.content()}</div>
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/components/pages/ShowcaseShowPage.jsx
+++ b/app/assets/javascripts/components/pages/ShowcaseShowPage.jsx
@@ -45,13 +45,21 @@ var ShowcaseShowPage = React.createClass({
   },
 
   render: function() {
+    var showcaseShow;
+    if (this.state.showcase) {
+      showcaseShow = (
+        <ShowcaseShow height={this.state.height} showcase={this.state.showcase} />
+      );
+    } else {
+      showcaseShow = (<Loading />);
+    }
     return (
       <div>
         {this.modals()}
         <Layout>
           <CollectionPageHeader collection={this.state.collection} dropdown={true} />
           <PageContent>
-            <ShowcaseShow height={this.state.height} showcase={this.state.showcase} />
+            {showcaseShow}
           </PageContent>
         </Layout>
         <CollectionOverlayFooter collection={this.state.collection} />

--- a/app/assets/javascripts/components/showcase/ShowcaseShow.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseShow.jsx
@@ -21,11 +21,13 @@ var ShowcaseShow = React.createClass({
       titleSectionPercentVisible: 1,
       startTime: Date.now(),
       hasScrolled: false,
+      outerElement: null,
+      element: null,
     }
   },
 
   componentDidUpdate: function(prevProps, prevState) {
-    if (this.props.showcase && !this.scrollbarInitialized) {
+    if (!this.scrollbarInitialized) {
       this.initializeScrollbar();
     }
     this.checkHash();
@@ -36,22 +38,26 @@ var ShowcaseShow = React.createClass({
 
   initializeScrollbar: function() {
     this.scrollbarInitialized = true;
-    $("#showcase-outer").perfectScrollbar({useBothWheelAxes: true, suppressScrollY: true });
+    this.state.outerElement.perfectScrollbar({useBothWheelAxes: true, suppressScrollY: true });
     if(this.ie()) {
-      $(".ps-scrollbar-x-rail").hide();
+      this.state.outerElement.find(".ps-scrollbar-x-rail").hide();
     }
   },
 
   updateScrollbar: function() {
     if (this.scrollbarInitialized) {
-      $("#showcase-outer").perfectScrollbar("update");
+      this.state.outerElement.perfectScrollbar("update");
       if(this.ie()) {
-        $(".ps-scrollbar-x-rail").hide();
+        this.state.outerElement.find(".ps-scrollbar-x-rail").hide();
       }
     }
   },
 
   componentDidMount: function() {
+    this.setState({
+      outerElement: $(React.findDOMNode(this.refs.showcaseOuter)),
+      element: $(React.findDOMNode(this)),
+    });
     window.addEventListener("hashchange", this.checkHash, false);
     // window.addEventListener("resize", this.handleResize, false);
     this.checkHash();
@@ -89,8 +95,8 @@ var ShowcaseShow = React.createClass({
     if(!this.state.hasScrolled) {
       this.setState({hasScrolled: true});
     }
-    var scrollLeft = $("#showcase-outer").get(0).scrollLeft;
-    var titleWidth = $(this.getDOMNode()).width() * titleSectionWidthPercent;
+    var scrollLeft = this.state.outerElement.get(0).scrollLeft;
+    var titleWidth = this.state.element.width() * titleSectionWidthPercent;
     var percentVisible = 1 - scrollLeft/titleWidth;
     if (percentVisible < 0) {
       percentVisible = 0;
@@ -116,21 +122,17 @@ var ShowcaseShow = React.createClass({
     } else if (backgroundBlur > maxBackgroundBlur) {
       backgroundBlur = maxBackgroundBlur;
     }
-    if (this.props.showcase) {
-      return (
-        <div>
-          <AttentionHelp start={this.state.startTime} hasScrolled={this.state.hasScrolled} />
-          <ShowcaseBackground percentBlur={backgroundBlur} height={this.props.height} showcase={this.props.showcase} />
-          <ShowcaseTitleBar percentFade={this.state.titleSectionPercentVisible} height={showcaseTitleHeight} showcase={this.props.showcase} />
-          <div id="showcase-outer" className="showcase-outer" style={this.styleOuter(showcaseHeight)} onScroll={this.onScroll}>
-            <Scroller target="#showcase-outer" />
-            <ShowcaseInnerContent height={showcaseInnerHeight} showcase={this.props.showcase} />
-          </div>
+    return (
+      <div>
+        <AttentionHelp start={this.state.startTime} hasScrolled={this.state.hasScrolled} />
+        <ShowcaseBackground percentBlur={backgroundBlur} height={this.props.height} showcase={this.props.showcase} />
+        <ShowcaseTitleBar percentFade={this.state.titleSectionPercentVisible} height={showcaseTitleHeight} showcase={this.props.showcase} />
+        <div id="showcase-outer" ref="showcaseOuter" className="showcase-outer" style={this.styleOuter(showcaseHeight)} onScroll={this.onScroll}>
+          <Scroller target="#showcase-outer" />
+          <ShowcaseInnerContent height={showcaseInnerHeight} showcase={this.props.showcase} />
         </div>
-      );
-    } else {
-      return (<Loading />);
-    }
+      </div>
+    );
   }
 });
 

--- a/app/assets/javascripts/components/showcase/ShowcaseShow.jsx
+++ b/app/assets/javascripts/components/showcase/ShowcaseShow.jsx
@@ -26,7 +26,7 @@ var ShowcaseShow = React.createClass({
 
   componentDidUpdate: function(prevProps, prevState) {
     if (this.props.showcase && !this.scrollbarInitialized) {
-      setTimeout(this.initializeScrollbar, 1000);
+      this.initializeScrollbar();
     }
     this.checkHash();
     if (this.props.height != prevProps.height) {

--- a/app/assets/stylesheets/showcase.css.scss
+++ b/app/assets/stylesheets/showcase.css.scss
@@ -270,7 +270,7 @@ $transparent-white: rgba(244, 244, 244, 0.8);
   }
 
   100% {
-    margin-left: 0%;
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
1. Multiple images could cause initial Showcase loading to stutter because the modals were instantiating instances of Openseadragon.  This delays rendering of modal content until it's made visible for the first time.
2. It was impossible to scroll during the slidein animation. This initializes the scrollbar immediately on load so scrolling can take place.
3. Another minor optimization on ShowcaseShow to store frequently referenced DOM nodes in the state.