### PR TITLE
CollectionLeftNav repeatedly requests showcase list when a collection has none.

### DIFF
--- a/app/assets/javascripts/components/layout/CollectionLeftNav.jsx
+++ b/app/assets/javascripts/components/layout/CollectionLeftNav.jsx
@@ -16,8 +16,8 @@ var CollectionLeftNav = React.createClass({
     };
   },
 
-  componentWillReceiveProps: function(nextProps) {
-    var url = nextProps.collection['@id'] + '/showcases';
+  componentDidMount: function() {
+    var url = this.props.collection['@id'] + '/showcases';
     $.ajax({
       context: this,
       type: "GET",

--- a/app/assets/javascripts/components/layout/CollectionLeftNav.jsx
+++ b/app/assets/javascripts/components/layout/CollectionLeftNav.jsx
@@ -18,16 +18,24 @@ var CollectionLeftNav = React.createClass({
 
   componentWillReceiveProps: function(nextProps) {
     var url = nextProps.collection['@id'] + '/showcases';
-    var request = new XMLHttpRequest();
-    request.open('GET', url, true);
-    request.onload = function() {
-      var showcases = JSON.parse(request.response).showcases;
-      this.setState({
-        showcases: showcases,
-      });
-    }.bind(this);
-
-    request.send();
+    $.ajax({
+      context: this,
+      type: "GET",
+      url: url,
+      dataType: "json",
+      success: function(result) {
+        var showcases = result.showcases;
+        this.setState({
+          showcases: showcases,
+        });
+      },
+      error: function(request, status, thrownError) {
+        // Should we redirect here? It's probably not necessary since it's not
+        // the primary content of the page...
+        //window.location = window.location.origin + '/404';
+        console.log("Error retrieving showcase list " + thrownError);
+      }
+    });
   },
 
   dropDownOptions: function() {

--- a/app/assets/javascripts/components/layout/CollectionLeftNav.jsx
+++ b/app/assets/javascripts/components/layout/CollectionLeftNav.jsx
@@ -16,20 +16,15 @@ var CollectionLeftNav = React.createClass({
     };
   },
 
-  componentDidUpdate: function() {
-    if(!this.props.collection['@id'] || this.state.showcases.length > 0) {
-      return [];
-    }
-    var url = this.props.collection['@id'] + '/showcases';
+  componentWillReceiveProps: function(nextProps) {
+    var url = nextProps.collection['@id'] + '/showcases';
     var request = new XMLHttpRequest();
     request.open('GET', url, true);
     request.onload = function() {
       var showcases = JSON.parse(request.response).showcases;
-      if (this.isMounted()) {
-        this.setState({
-          showcases: showcases,
-        });
-      }
+      this.setState({
+        showcases: showcases,
+      });
     }.bind(this);
 
     request.send();

--- a/app/assets/javascripts/components/pages/Collection/Collection.jsx
+++ b/app/assets/javascripts/components/pages/Collection/Collection.jsx
@@ -5,19 +5,6 @@ var mui = require('material-ui');
 var Collection = React.createClass({
   mixins: [LoadRemoteMixin, MuiThemeMixin],
 
-  propTypes: {
-    collection: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object,
-    ]),
-  },
-
-  getInitialState: function() {
-    return {
-      collection: {},
-    };
-  },
-
   componentDidMount: function() {
     if ('object' == typeof(this.props.collection)) {
       this.setState({
@@ -26,13 +13,6 @@ var Collection = React.createClass({
     } else {
       this.loadRemoteCollection(this.props.collection);
     }
-  },
-
-  setValues: function(collection) {
-    this.setState({
-      remoteCollectionLoaded: true,
-      collection: collection,
-    });
   },
 
   componentWillMount: function(){
@@ -47,7 +27,7 @@ var Collection = React.createClass({
 
   render: function() {
     if(!this.state.remoteCollectionLoaded)
-      return <div/>;
+      return null;
 
     return (
       <mui.AppCanvas>

--- a/app/assets/javascripts/components/pages/Collection/Collection.jsx
+++ b/app/assets/javascripts/components/pages/Collection/Collection.jsx
@@ -26,8 +26,9 @@ var Collection = React.createClass({
   },
 
   render: function() {
-    if(!this.state.remoteCollectionLoaded)
+    if(!this.state.remoteCollectionLoaded) {
       return null;
+    }
 
     return (
       <mui.AppCanvas>

--- a/app/assets/javascripts/components/pages/Collection/Collection.jsx
+++ b/app/assets/javascripts/components/pages/Collection/Collection.jsx
@@ -30,6 +30,7 @@ var Collection = React.createClass({
 
   setValues: function(collection) {
     this.setState({
+      remoteCollectionLoaded: true,
       collection: collection,
     });
   },
@@ -45,6 +46,9 @@ var Collection = React.createClass({
   },
 
   render: function() {
+    if(!this.state.remoteCollectionLoaded)
+      return <div/>;
+
     return (
       <mui.AppCanvas>
         <div className="collection-show-page">

--- a/app/assets/javascripts/components/pages/CollectionIntroduction/CollectionIntroduction.jsx
+++ b/app/assets/javascripts/components/pages/CollectionIntroduction/CollectionIntroduction.jsx
@@ -5,19 +5,6 @@ var mui = require('material-ui');
 var CollectionIntroduction = React.createClass({
   mixins: [LoadRemoteMixin, MuiThemeMixin],
 
-  propTypes: {
-    collection: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object,
-    ]),
-  },
-
-  getInitialState: function() {
-    return {
-      collection: {},
-    };
-  },
-
   componentDidMount: function() {
     if ("object" == typeof(this.props.collection)) {
       this.setState({
@@ -28,16 +15,9 @@ var CollectionIntroduction = React.createClass({
     }
   },
 
-  setValues: function(collection) {
-    this.setState({
-      remoteCollectionLoaded: true,
-      collection: collection,
-    });
-  },
-
   render: function() {
     if(!this.state.remoteCollectionLoaded)
-      return <div/>;
+      return null;
 
     var nextShowcase;
     if (this.state.collection.showcases && this.state.collection.showcases.length > 0) {

--- a/app/assets/javascripts/components/pages/CollectionIntroduction/CollectionIntroduction.jsx
+++ b/app/assets/javascripts/components/pages/CollectionIntroduction/CollectionIntroduction.jsx
@@ -30,11 +30,15 @@ var CollectionIntroduction = React.createClass({
 
   setValues: function(collection) {
     this.setState({
+      remoteCollectionLoaded: true,
       collection: collection,
     });
   },
 
   render: function() {
+    if(!this.state.remoteCollectionLoaded)
+      return <div/>;
+
     var nextShowcase;
     if (this.state.collection.showcases && this.state.collection.showcases.length > 0) {
       nextShowcase = (<PreviewLink showcase={this.state.collection.showcases[0]} />);

--- a/app/assets/javascripts/components/pages/CollectionIntroduction/CollectionIntroduction.jsx
+++ b/app/assets/javascripts/components/pages/CollectionIntroduction/CollectionIntroduction.jsx
@@ -16,8 +16,9 @@ var CollectionIntroduction = React.createClass({
   },
 
   render: function() {
-    if(!this.state.remoteCollectionLoaded)
+    if(!this.state.remoteCollectionLoaded) {
       return null;
+    }
 
     var nextShowcase;
     if (this.state.collection.showcases && this.state.collection.showcases.length > 0) {

--- a/app/assets/javascripts/components/pages/Pages/AboutPage.jsx
+++ b/app/assets/javascripts/components/pages/Pages/AboutPage.jsx
@@ -29,11 +29,15 @@ var AboutPage = React.createClass({
 
   setValues: function(collection) {
     this.setState({
+      remoteCollectionLoaded: true,
       collection: collection,
     });
   },
 
   render: function() {
+    if(!this.state.remoteCollectionLoaded)
+      return <div/>;
+
     var pageContent = (<Loading/>);
     if(this.state.collection && this.state.collection.about) {
       pageContent = (

--- a/app/assets/javascripts/components/pages/Pages/AboutPage.jsx
+++ b/app/assets/javascripts/components/pages/Pages/AboutPage.jsx
@@ -15,8 +15,9 @@ var AboutPage = React.createClass({
   },
 
   render: function() {
-    if(!this.state.remoteCollectionLoaded)
+    if(!this.state.remoteCollectionLoaded) {
       return null;
+    }
 
     var pageContent = (<Loading/>);
     if(this.state.collection && this.state.collection.about) {

--- a/app/assets/javascripts/components/pages/Pages/AboutPage.jsx
+++ b/app/assets/javascripts/components/pages/Pages/AboutPage.jsx
@@ -4,19 +4,6 @@ var mui = require('material-ui');
 var AboutPage = React.createClass({
   mixins: [LoadRemoteMixin, MuiThemeMixin],
 
-  propTypes: {
-    collection: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object,
-    ]),
-  },
-
-  getInitialState: function() {
-    return {
-      collection: {},
-    };
-  },
-
   componentDidMount: function() {
     if ('object' == typeof(this.props.collection)) {
       this.setState({
@@ -27,16 +14,9 @@ var AboutPage = React.createClass({
     }
   },
 
-  setValues: function(collection) {
-    this.setState({
-      remoteCollectionLoaded: true,
-      collection: collection,
-    });
-  },
-
   render: function() {
     if(!this.state.remoteCollectionLoaded)
-      return <div/>;
+      return null;
 
     var pageContent = (<Loading/>);
     if(this.state.collection && this.state.collection.about) {

--- a/app/assets/javascripts/components/pages/Pages/Page.jsx
+++ b/app/assets/javascripts/components/pages/Pages/Page.jsx
@@ -4,19 +4,6 @@ var mui = require('material-ui');
 var Page = React.createClass({
   mixins: [LoadRemoteMixin, MuiThemeMixin],
 
-  propTypes: {
-    collection: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object,
-    ]),
-  },
-
-  getInitialState: function() {
-    return {
-      collection: {},
-    };
-  },
-
   componentDidMount: function() {
     if ('object' == typeof(this.props.collection)) {
       this.setState({
@@ -27,16 +14,9 @@ var Page = React.createClass({
     }
   },
 
-  setValues: function(collection) {
-    this.setState({
-      remoteCollectionLoaded: true,
-      collection: collection,
-    });
-  },
-
   render: function() {
     if(!this.state.remoteCollectionLoaded)
-      return <div/>;
+      return null;
 
     var pageContent = (<Loading/>);
     var pageName;

--- a/app/assets/javascripts/components/pages/Pages/Page.jsx
+++ b/app/assets/javascripts/components/pages/Pages/Page.jsx
@@ -29,11 +29,15 @@ var Page = React.createClass({
 
   setValues: function(collection) {
     this.setState({
+      remoteCollectionLoaded: true,
       collection: collection,
     });
   },
 
   render: function() {
+    if(!this.state.remoteCollectionLoaded)
+      return <div/>;
+
     var pageContent = (<Loading/>);
     var pageName;
     if(this.state.collection && this.state.collection.pages) {

--- a/app/assets/javascripts/components/pages/Pages/Page.jsx
+++ b/app/assets/javascripts/components/pages/Pages/Page.jsx
@@ -15,8 +15,9 @@ var Page = React.createClass({
   },
 
   render: function() {
-    if(!this.state.remoteCollectionLoaded)
+    if(!this.state.remoteCollectionLoaded) {
       return null;
+    }
 
     var pageContent = (<Loading/>);
     var pageName;

--- a/app/assets/javascripts/components/pages/Search/Search.jsx
+++ b/app/assets/javascripts/components/pages/Search/Search.jsx
@@ -54,8 +54,9 @@ var Search = React.createClass({
   },
 
   render: function() {
-    if(!this.state.remoteCollectionLoaded)
+    if(!this.state.remoteCollectionLoaded) {
       return null;
+    }
 
     return (
       <mui.AppCanvas>

--- a/app/assets/javascripts/components/pages/Search/Search.jsx
+++ b/app/assets/javascripts/components/pages/Search/Search.jsx
@@ -60,11 +60,15 @@ var Search = React.createClass({
 
   setValues: function(collection) {
     this.setState({
+      remoteCollectionLoaded: true,
       collection: collection
     });
   },
 
   render: function() {
+    if(!this.state.remoteCollectionLoaded)
+      return <div/>;
+
     return (
       <mui.AppCanvas>
         <CollectionPageHeader collection={this.state.collection} ></CollectionPageHeader>

--- a/app/assets/javascripts/components/pages/Search/Search.jsx
+++ b/app/assets/javascripts/components/pages/Search/Search.jsx
@@ -7,10 +7,6 @@ var Search = React.createClass({
   mixins: [SearchUrlMixin, LoadRemoteMixin, SearchMixin, MuiThemeMixin ],
 
   propTypes: {
-    collection: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.array,
-    ]),
     hits: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.array,
@@ -23,7 +19,6 @@ var Search = React.createClass({
 
   getInitialState: function() {
     return {
-      collection: {},
       items: [],
       sortOptions: [],
       selectedIndex: 0,
@@ -58,16 +53,9 @@ var Search = React.createClass({
     this.loadSearchResults(url);
   },
 
-  setValues: function(collection) {
-    this.setState({
-      remoteCollectionLoaded: true,
-      collection: collection
-    });
-  },
-
   render: function() {
     if(!this.state.remoteCollectionLoaded)
-      return <div/>;
+      return null;
 
     return (
       <mui.AppCanvas>

--- a/app/assets/javascripts/components/pages/Showcase/Showcase.jsx
+++ b/app/assets/javascripts/components/pages/Showcase/Showcase.jsx
@@ -5,16 +5,8 @@ var mui = require('material-ui');
 var Showcase = React.createClass({
   mixins: [PageHeightMixin, LoadRemoteMixin, MuiThemeMixin, CurrentThemeMixin],
 
-  propTypes: {
-    collection: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object,
-    ]),
-  },
-
   getInitialState: function() {
     return {
-      collection: {},
       showcase: null,
       currentSection: null,
     };
@@ -26,6 +18,7 @@ var Showcase = React.createClass({
       collection: collection,
       showcase: collection.showcases,
     }, this.handleResize);
+    return true;
   },
 
   componentWillMount: function() {
@@ -55,7 +48,7 @@ var Showcase = React.createClass({
 
   render: function() {
     if(!this.state.remoteCollectionLoaded)
-      return <div/>;
+      return null;
 
     var showcaseShow;
     if (this.state.showcase) {

--- a/app/assets/javascripts/components/pages/Showcase/Showcase.jsx
+++ b/app/assets/javascripts/components/pages/Showcase/Showcase.jsx
@@ -47,8 +47,9 @@ var Showcase = React.createClass({
   },
 
   render: function() {
-    if(!this.state.remoteCollectionLoaded)
+    if(!this.state.remoteCollectionLoaded) {
       return null;
+    }
 
     var showcaseShow;
     if (this.state.showcase) {

--- a/app/assets/javascripts/components/pages/Showcase/Showcase.jsx
+++ b/app/assets/javascripts/components/pages/Showcase/Showcase.jsx
@@ -22,6 +22,7 @@ var Showcase = React.createClass({
 
   setValues: function(collection) {
     this.setState({
+      remoteCollectionLoaded: true,
       collection: collection,
       showcase: collection.showcases,
     }, this.handleResize);
@@ -53,6 +54,9 @@ var Showcase = React.createClass({
   },
 
   render: function() {
+    if(!this.state.remoteCollectionLoaded)
+      return <div/>;
+
     var showcaseShow;
     if (this.state.showcase) {
       showcaseShow = (
@@ -61,7 +65,7 @@ var Showcase = React.createClass({
     } else {
       showcaseShow = (<Loading />);
     }
-    // this is a div instead of mui.AppCanvas because of a bug in 12.3 which is fixed in master.  
+    // this is a div instead of mui.AppCanvas because of a bug in 12.3 which is fixed in master.
     return (
       <div style={{ backgroundColor: 'inherit' }}>
         <CollectionPageHeader collection={this.state.collection} />

--- a/app/assets/javascripts/components/pages/SiteIndex/SiteIndex.jsx
+++ b/app/assets/javascripts/components/pages/SiteIndex/SiteIndex.jsx
@@ -30,6 +30,7 @@ var SiteIndex = React.createClass({
 
   setValues: function(collections) {
     this.setState({
+      remoteCollectionLoaded: true,
       collections: collections,
     });
   },
@@ -39,6 +40,9 @@ var SiteIndex = React.createClass({
   },
 
   render: function() {
+    if(!this.state.remoteCollectionLoaded)
+      return <div/>;
+
     return (
       <mui.AppCanvas>
         <BrandBar/>

--- a/app/assets/javascripts/components/pages/SiteIndex/SiteIndex.jsx
+++ b/app/assets/javascripts/components/pages/SiteIndex/SiteIndex.jsx
@@ -41,8 +41,9 @@ var SiteIndex = React.createClass({
   },
 
   render: function() {
-    if(!this.state.remoteCollectionLoaded)
+    if(!this.state.remoteCollectionLoaded) {
       return null;
+    }
 
     return (
       <mui.AppCanvas>

--- a/app/assets/javascripts/components/pages/SiteIndex/SiteIndex.jsx
+++ b/app/assets/javascripts/components/pages/SiteIndex/SiteIndex.jsx
@@ -33,6 +33,7 @@ var SiteIndex = React.createClass({
       remoteCollectionLoaded: true,
       collections: collections,
     });
+    return true;
   },
 
   componentWillMount: function(){
@@ -41,7 +42,7 @@ var SiteIndex = React.createClass({
 
   render: function() {
     if(!this.state.remoteCollectionLoaded)
-      return <div/>;
+      return null;
 
     return (
       <mui.AppCanvas>

--- a/app/assets/javascripts/mixins/LoadRemoteMixin.jsx
+++ b/app/assets/javascripts/mixins/LoadRemoteMixin.jsx
@@ -1,6 +1,14 @@
 var LoadRemoteMixin = {
+  propTypes: {
+    collection: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.object,
+    ]),
+  },
+
   getInitialState: function() {
     return {
+      collection: {},
       remoteCollectionLoaded: false,
     };
   },
@@ -12,7 +20,15 @@ var LoadRemoteMixin = {
       url: url,
       dataType: 'json',
       success: function(result) {
-        this.setValues(result);
+        // If the object has a setValues method and it returns true, it means the object
+        // has already set the state and we should not do it again.
+        if(this.setValues == undefined || !this.setValues(result))
+        {
+          this.setState({
+            remoteCollectionLoaded: true,
+            collection: result,
+          });
+        }
       },
       error: function(request, status, thrownError) {
         window.location = window.location.origin + '/404';

--- a/app/assets/javascripts/mixins/LoadRemoteMixin.jsx
+++ b/app/assets/javascripts/mixins/LoadRemoteMixin.jsx
@@ -1,4 +1,10 @@
 var LoadRemoteMixin = {
+  getInitialState: function() {
+    return {
+      remoteCollectionLoaded: false,
+    };
+  },
+
   loadRemoteCollection: function(url) {
     $.ajax({
       context: this,


### PR DESCRIPTION
When the collection had no showcases it would always cause a setState inside of the componentDidUpdate, causing infinite loop. Changed to perform an ajax request on mount. This is the earliest point in the lifecycle that we can reliably get the collection and it should only happen once per instance. I also had to change all parent objects that use the LoadRemoteMixin to delay rendering until it had a valid collection since almost all of the child objects rely having a valid collection given as a prop. Also refactored a small amount of repeated code associated with setting state once collection data is received by the LoadRemoteMixin.