### PR TITLE
Next/Previous buttons when zooming in on an item do not work in search/browse

### DIFF
--- a/app/assets/javascripts/components/pages/Search/ItemPanel.jsx
+++ b/app/assets/javascripts/components/pages/Search/ItemPanel.jsx
@@ -4,7 +4,7 @@ var mui = require('material-ui');
 var CloseButton = require('../../other/CloseButton');
 var SideNavButton = require("../../other/SideNavButton");
 var OverlayPage = require("../../layout/OverlayPage");
-var SearchStore = require('../../../stores/Search');
+var SearchStore = require('../../../stores/SearchStore');
 
 var ItemPanel = React.createClass({
   mixins: [ CurrentThemeMixin, CollectionUrlMixin, LoadRemoteMixin ],
@@ -48,6 +48,7 @@ var ItemPanel = React.createClass({
       nextItem: nextItem,
       previousItem: previousItem,
     });
+    window.location.hash = item['@id'].split("/").pop();
   },
 
   removeCurrentItem: function() {

--- a/app/assets/javascripts/components/pages/Search/ItemPanel.jsx
+++ b/app/assets/javascripts/components/pages/Search/ItemPanel.jsx
@@ -4,6 +4,7 @@ var mui = require('material-ui');
 var CloseButton = require('../../other/CloseButton');
 var SideNavButton = require("../../other/SideNavButton");
 var OverlayPage = require("../../layout/OverlayPage");
+var SearchStore = require('../../../stores/Search');
 
 var ItemPanel = React.createClass({
   mixins: [ CurrentThemeMixin, CollectionUrlMixin, LoadRemoteMixin ],
@@ -18,6 +19,8 @@ var ItemPanel = React.createClass({
   getInitialState: function() {
     return {
       currentItem: null,
+      nextItem: null,
+      previousItem: null
     };
   },
 
@@ -38,8 +41,12 @@ var ItemPanel = React.createClass({
   },
 
   setCurrentItem: function(item) {
+    var previousItem = SearchStore.getPreviousItem(item);
+    var nextItem = SearchStore.getNextItem(item);
     this.setState({
       currentItem: item,
+      nextItem: nextItem,
+      previousItem: previousItem,
     });
   },
 
@@ -55,13 +62,15 @@ var ItemPanel = React.createClass({
   },
 
   nextButtonClick: function() {
-    //console.log("next");
-    ItemActions.showItemDialogWindow(this.state.currentItem);
+    if(this.state.nextItem) {
+      this.loadRemoteItem(this.state.nextItem["@id"]);
+    }
   },
 
   prevButtonClick: function() {
-    //console.log("previous");
-    ItemActions.showItemDialogWindow(this.state.currentItem);
+    if(this.state.previousItem) {
+      this.loadRemoteItem(this.state.previousItem["@id"]);
+    }
   },
 
   render: function() {
@@ -73,9 +82,9 @@ var ItemPanel = React.createClass({
       <OverlayPage
         title={this.state.currentItem.name}
         onCloseButtonClick={this.closeButtonClick}
-        onNextButtonClick={this.nextButtonClick}
-        onPrevButtonClick={this.prevButtonClick}
-        >
+        onNextButtonClick={this.state.nextItem ? this.nextButtonClick : null}
+        onPrevButtonClick={this.state.previousItem ? this.prevButtonClick : null}
+      >
         <ItemShow item={this.state.currentItem} />
       </OverlayPage>
     );

--- a/app/assets/javascripts/stores/SearchStore.js
+++ b/app/assets/javascripts/stores/SearchStore.js
@@ -211,6 +211,33 @@ class SearchStore extends EventEmitter {
         break;
     }
   }
+
+  getNextItem(item) {
+    for(var i = 0; i < this.items.length; ++i) {
+      if(this.items[i]["@id"] == item["@id"]) {
+        var nextI = (i + 1);
+        if(nextI > this.items.length - 1)
+          return null;
+        else
+          return this.items[nextI];
+      }
+    }
+    return null;
+  }
+
+  getPreviousItem(item) {
+    for(var i = 0; i < this.items.length; ++i) {
+      if(this.items[i]["@id"] == item["@id"]) {
+        var prevI = i - 1;
+        if(prevI < 0) {
+          return null;
+        } else {
+          return this.items[prevI];
+        }
+      }
+    }
+    return null;
+  }
 }
 
 var searchStore = new SearchStore();

--- a/app/assets/javascripts/stores/SearchStore.js
+++ b/app/assets/javascripts/stores/SearchStore.js
@@ -216,10 +216,11 @@ class SearchStore extends EventEmitter {
     for(var i = 0; i < this.items.length; ++i) {
       if(this.items[i]["@id"] == item["@id"]) {
         var nextI = (i + 1);
-        if(nextI > this.items.length - 1)
+        if(nextI > this.items.length - 1) {
           return null;
-        else
+        } else {
           return this.items[nextI];
+        }
       }
     }
     return null;


### PR DESCRIPTION
Added methods in the store to get items adjacent to a given item. Anytime the selected item changes, the ItemPanel will try to get next/previous items to use within the button click methods. If there is no next/previous item it will disable the appropriate button.