### PR TITLE
Fluxify further

### DIFF
--- a/app/assets/javascripts/actions/SearchActions.js
+++ b/app/assets/javascripts/actions/SearchActions.js
@@ -44,30 +44,6 @@ class SearchActions {
     });
   }
 
-  // Shows the item in a zoomed in window
-  showItem(item) {
-    AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_SHOW_ITEM,
-      item: item
-    });
-  }
-
-  // Shows the next item in the search results, relative to the given item
-  showNextItem(item) {
-    AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_SHOW_NEXT_ITEM,
-      item: item
-    });
-  }
-
-  // Shows the previous item in the search results, relative to the given item
-  showPreviousItem(item) {
-    AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_SHOW_PREVIOUS_ITEM,
-      item: item
-    });
-  }
-
   setView(view) {
     AppDispatcher.dispatch({
       actionType: SearchActionTypes.SEARCH_SET_VIEW,

--- a/app/assets/javascripts/components/layout/SearchBox.jsx
+++ b/app/assets/javascripts/components/layout/SearchBox.jsx
@@ -8,14 +8,11 @@ var SearchActions = require("../../actions/SearchActions");
 var SearchBox = React.createClass({
   mixins: [CurrentThemeMixin],
   propTypes: {
-    collection: React.PropTypes.object.isRequired,
-    searchTerm: React.PropTypes.string,
     primary: React.PropTypes.bool,
   },
 
   getDefaultProps: function() {
     return {
-      searchTerm: "",
       primary: true,
       active: false,
     };
@@ -23,7 +20,6 @@ var SearchBox = React.createClass({
 
   getInitialState: function() {
     var state = {
-      searchTerm: this.props.searchTerm,
       active: this.props.active,
     };
     return state;
@@ -44,7 +40,7 @@ var SearchBox = React.createClass({
   },
 
   componentDidMount: function() {
-    this.setTerm(this.props.searchTerm);
+    this.setTerm(SearchStore.searchTerm);
   },
 
   setTerm: function(term) {
@@ -72,7 +68,7 @@ var SearchBox = React.createClass({
         placeholder='search'
         ref='searchBox'
         onChange={this.onChange}
-        defaultValue={this.props.searchTerm}
+        defaultValue={SearchStore.searchTerm}
         onKeyDown={this.handleKeyDown}
         inputStyle={this.inputStyle()}
         style={{height:'36px', verticalAlign:'top'}}

--- a/app/assets/javascripts/components/pages/Search/Search.jsx
+++ b/app/assets/javascripts/components/pages/Search/Search.jsx
@@ -21,26 +21,9 @@ var Search = React.createClass({
     view: React.PropTypes.string,
   },
 
-  getInitialState: function() {
-    return {
-      items: [],
-      sortOptions: [],
-      selectedIndex: 0,
-      found: 0,
-      start: 0,
-    };
-  },
-
   searchStoreChanged: function(reason) {
     this.setState({
-      remoteCollectionLoaded: true,
-      collection: SearchStore.collection,
-      facets: SearchStore.facets,
-      sortOptions: SearchStore.sorts,
-      selectedIndex: SearchStore.selectedPageIndex,
-      items: SearchStore.items,
-      found: SearchStore.found,
-      start: SearchStore.start,
+      readyToRender: true,
     });
 
     if(reason == "load") {
@@ -74,6 +57,7 @@ var Search = React.createClass({
     }
   },
 
+  // Translates the facet option given in props to the structure the SearchStore expects.
   facetObject: function() {
     var facet;
     if(this.props.facet) {
@@ -84,38 +68,21 @@ var Search = React.createClass({
   },
 
   render: function() {
-    if(!this.state.remoteCollectionLoaded) {
+    // All children of this object expect the collection and all data to be loaded into the SearchStore.
+    // This will prevent mounting them until ready.
+    if(!this.state.readyToRender) {
       return null;
     }
 
     return (
       <mui.AppCanvas>
-        <CollectionPageHeader collection={this.state.collection} ></CollectionPageHeader>
-
+        <CollectionPageHeader collection={SearchStore.collection} ></CollectionPageHeader>
         <ItemPanel />
-
-        <SearchControls
-          collection={this.state.collection}
-          searchTerm={this.props.searchTerm}
-          sortOptions={this.state.sortOptions}
-          selectedIndex={this.state.selectedIndex}
-          searchStyle={{height:'50px'}}
-        />
-
+        <SearchControls searchStyle={{height:'50px'}}/>
         <PageContent fluidLayout={false}>
-          <SearchDisplayList
-            collection={this.state.collection}
-            items={this.state.items}
-            facets={this.state.facets}
-            sortOptions={this.state.sortOptions}
-            searchTerm={this.props.searchTerm}
-            selectedIndex={this.state.selectedIndex}
-            selectedFacet={this.facetObject()}
-            found={this.state.found}
-            start={this.state.start}
-          />
+          <SearchDisplayList />
         </PageContent>
-        <CollectionPageFooter collection={this.state.collection} />
+        <CollectionPageFooter collection={SearchStore.collection} />
       </mui.AppCanvas>
     );
   }

--- a/app/assets/javascripts/components/pages/Search/SearchControls.jsx
+++ b/app/assets/javascripts/components/pages/Search/SearchControls.jsx
@@ -13,13 +13,6 @@ var listView = {view: "list"};
 var SearchControls = React.createClass({
   mixins: [CurrentThemeMixin, CollectionUrlMixin],
 
-  propTypes: {
-    collection: React.PropTypes.object,
-    searchTerm: React.PropTypes.string,
-    selectedIndex: React.PropTypes.number,
-    sortOptions: React.PropTypes.array,
-  },
-
   getInitialState: function() {
     var state = {
       view: SearchStore.view,
@@ -60,7 +53,8 @@ var SearchControls = React.createClass({
   },
 
   componentWillMount: function() {
-    SearchStore.on("SearchStoreChanged", this.storeChanged);
+    // View changes don't change the top level query, so we have to listen
+    // for those changes in order to force a rerender
     SearchStore.on("SearchStoreViewChanged", this.storeViewChanged);
   },
 
@@ -83,15 +77,11 @@ var SearchControls = React.createClass({
       <div style={{height: "65px" }}>
       <mui.Toolbar className="controls" style={this.controlsStyle()}>
         <mui.ToolbarGroup key={0} float="left">
-          <SearchBox collection={this.props.collection} searchTerm={this.props.searchTerm} primary={false} active={true} />
+          <SearchBox primary={false} active={true} />
         </mui.ToolbarGroup>
         <mui.ToolbarGroup key={1} float="right">
           <MediaQuery minWidth={700}>
-            <SearchSort
-              collection={this.props.collection}
-              sortOptions={this.props.sortOptions}
-              selectedIndex={this.props.selectedIndex}
-              />
+            <SearchSort/>
               <mui.RaisedButton
                 secondary={this.state.view == 'list'}
                 onClick={this.setList}

--- a/app/assets/javascripts/components/pages/Search/SearchDisplayList.jsx
+++ b/app/assets/javascripts/components/pages/Search/SearchDisplayList.jsx
@@ -9,18 +9,6 @@ var SearchStore = require('../../../stores/SearchStore');
 var SearchDisplayList = React.createClass({
   mixins: [CollectionUrlMixin, MuiThemeMixin ],
 
-  propTypes: {
-    collection: React.PropTypes.object,
-    items: React.PropTypes.array,
-    facets: React.PropTypes.array,
-    searchTerm: React.PropTypes.string,
-    sortOptions: React.PropTypes.array,
-    selectedIndex: React.PropTypes.number,
-    selectedFacet: React.PropTypes.object,
-    found: React.PropTypes.number,
-    start: React.PropTypes.number,
-  },
-
   getInitialState: function () {
     return {
       sidebar: false,
@@ -28,24 +16,15 @@ var SearchDisplayList = React.createClass({
     };
   },
 
-  getDefaultProps: function() {
-    return {
-      items: [],
-      facets: [],
-      searchTerm: "",
-      found: 0,
-      start: 0,
-    };
-  },
-
   componentDidMount: function() {
-    if(this.props.sortOptions || this.props.facets) {
+    if(SearchStore.sorts || SearchStore.facets) {
       this.setState({sidebar: true});
     }
   },
 
   componentWillMount: function() {
-    SearchStore.on("SearchStoreChanged", this.storeViewChanged);
+    // View changes don't change the top level query, so we have to listen
+    // for those changes in order to force a rerender
     SearchStore.on("SearchStoreViewChanged", this.storeViewChanged);
   },
 
@@ -53,25 +32,9 @@ var SearchDisplayList = React.createClass({
     this.setState({ view: SearchStore.view });
   },
 
-  nextUrl: function(index) {
-    var id;
-    if (index <  SearchStore.items.length - 1) {
-      id = SearchStore.items[index + 1];
-    }
-    return id;
-  },
-
-  prevUrl: function(index) {
-    var id;
-    if (index > 0) {
-      id = SearchStore.items[index - 1];
-    }
-    return id;
-  },
-
   itemList: function() {
     var view = this.state.view;
-    var itemNodes = this.props.items.map(function(item, index) {
+    var itemNodes = SearchStore.items.map(function(item, index) {
       return (
         <ItemListItem
           item={item}
@@ -121,31 +84,16 @@ var SearchDisplayList = React.createClass({
         <MediaQuery maxWidth={700}>
           <mui.Paper zDepth={0}>
             {this.itemList()}
-
-            <SearchPagination
-              collection={this.props.collection}
-              found={this.props.found}
-              start={this.props.start}
-            />
+            <SearchPagination />
           </mui.Paper>
         </MediaQuery>
 
         <MediaQuery minWidth={700}>
-          <SearchSidebar
-            collection={this.props.collection}
-            show={this.state.sidebar}
-            facets={this.props.facets}
-            selectedFacet={this.props.selectedFacet}
-          />
+          <SearchSidebar show={this.state.sidebar} />
 
           <mui.Paper style={{width: "74%"}} zDepth={0}>
             {this.itemList()}
-
-            <SearchPagination
-              collection={this.props.collection}
-              found={this.props.found}
-              start={this.props.start}
-            />
+            <SearchPagination />
           </mui.Paper>
         </MediaQuery>
       </div>

--- a/app/assets/javascripts/components/pages/Search/SearchFacets.jsx
+++ b/app/assets/javascripts/components/pages/Search/SearchFacets.jsx
@@ -8,15 +8,10 @@ var SearchActions = require("../../../actions/SearchActions");
 
 var SearchFacets = React.createClass({
   mixins: [CurrentThemeMixin],
-  propTypes: {
-    collection: React.PropTypes.object.isRequired,
-    facets: React.PropTypes.array,
-    selectedFacet: React.PropTypes.object,
-  },
 
   getInitialState: function() {
     return {
-      selectedFacet: this.props.selectedFacet
+      selectedFacet: SearchStore.selectedFacet
     };
   },
 
@@ -46,7 +41,7 @@ var SearchFacets = React.createClass({
 
   facets: function(){
     self = this;
-    return this.props.facets.map(function(e, index) {
+    return SearchStore.facets.map(function(e, index) {
       return (
         <List
           key={e.name}

--- a/app/assets/javascripts/components/pages/Search/SearchPagination.jsx
+++ b/app/assets/javascripts/components/pages/Search/SearchPagination.jsx
@@ -4,21 +4,6 @@ var mui = require('material-ui');
 var SearchStore = require('../../../stores/SearchStore');
 
 var SearchPagination = React.createClass({
-  propTypes: {
-    collection: React.PropTypes.object.isRequired,
-    found: React.PropTypes.number,
-    start: React.PropTypes.number,
-    count: React.PropTypes.number,
-  },
-
-  getDefaultProps: function() {
-    return {
-      found: 0,
-      start: 0,
-      count: 12,
-    };
-  },
-
   paginationButton: function() {
     return {
       border:'solid 1px',
@@ -29,13 +14,13 @@ var SearchPagination = React.createClass({
   },
 
   pageLink: function(i) {
-    if(this.props.start === (i-1) * this.props.count){
+    if(SearchStore.start === (i-1) * SearchStore.rowLimit){
       return(
         <span style={this.paginationButton()}>{i}</span>
       );
     }
     else {
-      var searchUrl = window.location.origin + SearchStore.searchUri({ start: (i-1)*this.props.count });
+      var searchUrl = window.location.origin + SearchStore.searchUri({ start: (i-1)*SearchStore.rowLimit });
       return(
         <a href={searchUrl} style={this.paginationButton()}>{i}</a>
       );
@@ -45,16 +30,16 @@ var SearchPagination = React.createClass({
   pageLinks: function() {
     var nodes = [];
     // if not first page
-    if(this.props.start != 0) {
+    if(SearchStore.start != 0) {
       var backLink = window.location.origin + SearchStore.searchUri({ start: 0 });
       nodes.push((<a href={backLink}> <i className="material-icons" style={{fontSize: '1em',}}>arrow_back</i> </a>));
     }
-    var last = Math.floor(this.props.found/this.props.count);
-    var cappedFirst = Math.max(1, Math.floor(this.props.start/this.props.count) - 2);
-    var cappedLast = Math.min(Math.floor(this.props.start/this.props.count) + 4, last + 1);
-    if(this.props.found > this.props.count){
+    var last = Math.floor(SearchStore.found/SearchStore.rowLimit);
+    var cappedFirst = Math.max(1, Math.floor(SearchStore.start/SearchStore.rowLimit) - 2);
+    var cappedLast = Math.min(Math.floor(SearchStore.start/SearchStore.rowLimit) + 4, last + 1);
+    if(SearchStore.found > SearchStore.rowLimit){
 
-      if(this.props.found%this.props.count != 0){
+      if(SearchStore.found%SearchStore.rowLimit != 0){
         last += 1;
       }
       for (var i = cappedFirst; i <= cappedLast; i++) {
@@ -63,8 +48,8 @@ var SearchPagination = React.createClass({
     }
 
     // if not last page
-    if(this.props.start + this.props.count < this.props.found) {
-      var forwardLink = window.location.origin + SearchStore.searchUri({ start: this.props.count*(last - 1) });
+    if(SearchStore.start + SearchStore.rowLimit < SearchStore.found) {
+      var forwardLink = window.location.origin + SearchStore.searchUri({ start: SearchStore.rowLimit*(last - 1) });
       nodes.push((<a href={forwardLink}> <i className="material-icons" style={{fontSize: '1em'}}>arrow_forward</i> </a>));
     }
     return nodes;
@@ -73,13 +58,13 @@ var SearchPagination = React.createClass({
   render: function() {
     // people think of the first record as 1, not 0.
     // Am I not a people?
-    var startHuman = this.props.start + 1;
-    var endHuman = Math.min(this.props.start + this.props.count, this.props.found);
+    var startHuman = SearchStore.start + 1;
+    var endHuman = Math.min(SearchStore.start + SearchStore.rowLimit, SearchStore.found);
     return (
       <div style={{margin: '2em 0 4em', float:'right'}}>
         <div style={{color:'rgba(0, 0, 0, 0.870588)', float: 'right', textAlign: 'right'}}>
           <div className="pagination">
-            <span style={{marginRight:'15px', display:'inline-block', verticalAlign:'top'}}>Showing {startHuman} - {endHuman} of {this.props.found}</span>
+            <span style={{marginRight:'15px', display:'inline-block', verticalAlign:'top'}}>Showing {startHuman} - {endHuman} of {SearchStore.found}</span>
             {this.pageLinks()}
           </div>
         </div>

--- a/app/assets/javascripts/components/pages/Search/SearchSidebar.jsx
+++ b/app/assets/javascripts/components/pages/Search/SearchSidebar.jsx
@@ -4,14 +4,6 @@ var mui = require('material-ui');
 
 var SearchSidebar = React.createClass({
   mixins: [PageHeightMixin],
-  propTypes: {
-    collection: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.array,
-    ]),
-    facets: React.PropTypes.array,
-    selectedFacet: React.PropTypes.object,
-  },
 
   getInitialState: function () {
     return {
@@ -23,24 +15,12 @@ var SearchSidebar = React.createClass({
     this.setState({show: !this.state.show});
   },
 
-  searchSort: function() {
-    var searchSort;
-    if(this.props.sortOptions && this.props.sortOptions.length > 1) {
-        searchSort = (<SearchSort
-          collection={this.props.collection}
-          sortOptions={this.props.sortOptions}
-          selectedIndex={this.props.selectedIndex}
-        />);
-    }
-    return searchSort;
-  },
-
   render: function() {
     return (
       <mui.Paper style={{display: this.state.show ? 'block' : 'none', width: "25%", float: "right"}} >
         <h3 style={{paddingLeft:'16px'}}>Filter Results</h3>
         <hr/>
-        <SearchFacets collection={this.props.collection} facets={this.props.facets} selectedFacet={this.props.selectedFacet} />
+        <SearchFacets/>
       </mui.Paper>
     );
   }

--- a/app/assets/javascripts/components/pages/Search/SearchSort.jsx
+++ b/app/assets/javascripts/components/pages/Search/SearchSort.jsx
@@ -7,12 +7,6 @@ var SearchStore = require('../../../stores/SearchStore');
 var SearchActions = require('../../../actions/SearchActions');
 
 var SearchSort = React.createClass({
-  propTypes: {
-    collection: React.PropTypes.object.isRequired,
-    sortOptions: React.PropTypes.array,
-    selectedIndex: React.PropTypes.number,
-  },
-
   getInitialState: function() {
     var state = {
       selectValue: 0,
@@ -20,19 +14,12 @@ var SearchSort = React.createClass({
     return state;
   },
 
-  getDefaultProps: function() {
-    return {
-      sortOptions: [],
-      selectedIndex: -1,
-    };
-  },
-
   onChange: function(prop, e) {
-    SearchActions.setSort(e.target.value);
+    this.setSort(e.target.value);
   },
 
   setSort: function(sortOption) {
-    SearchStore.sortOption = sortOption;
+    SearchActions.setSort(sortOption);
   },
 
   componentWillMount: function() {
@@ -42,10 +29,6 @@ var SearchSort = React.createClass({
       sortOption = window.location.search.replace(regex, '').split('&')[0];
     }
     this.setSort(sortOption);
-  },
-
-  shouldComponentUpdate: function(nextProps, nextState) {
-    return(nextProps.selectedIndex !== this.props.selectedIndex);
   },
 
   sortStyle: function() {
@@ -75,21 +58,13 @@ var SearchSort = React.createClass({
   },
 
   sortOptions: function() {
-    return this.props.sortOptions.map(function(option) {
+    return SearchStore.sorts.map(function(option) {
       return(<option key={option.value} value={option.value}>{option.name}</option>);
     });
   },
 
-  selectedValue: function() {
-    if (this.props.selectedIndex > -1 ) {
-      return this.props.sortOptions[this.props.selectedIndex].value;
-    } else {
-      return this.props.sortOptions[0].value
-    }
-  },
-
   render: function() {
-    if(this.props.sortOptions.length > 0) {
+    if(SearchStore.sorts.length > 0) {
       return(
       <div style={{float: "left", padding: '10px', paddingTop: '15px', color: 'white', fontSize: '16px'}}>
         Sort By:
@@ -98,8 +73,8 @@ var SearchSort = React.createClass({
             ref='searchSort'
             autoWidth={false}
             onChange={this.onChange.bind(this, 'selectValue')}
-            menuItems={this.props.sortOptions}
-            defaultValue={this.selectedValue()}
+            menuItems={SearchStore.sorts}
+            defaultValue={SearchStore.sortOption}
             style={this.sortSelectStyle()}
           >
           {this.sortOptions()}

--- a/app/assets/javascripts/constants/SearchActionTypes.jsx
+++ b/app/assets/javascripts/constants/SearchActionTypes.jsx
@@ -7,9 +7,6 @@ var SearchActionTypes = keyMirror({
   SEARCH_SET_SELECTED_FACET: null,
   SEARCH_SET_TERM: null,
   SEARCH_SET_VIEW: null,
-  SEARCH_SHOW_ITEM: null,
-  SEARCH_SHOW_NEXT_ITEM: null,
-  SEARCH_SHOW_PREVIOUS_ITEM: null
 });
 
 module.exports = SearchActionTypes;

--- a/app/assets/javascripts/stores/SearchStore.js
+++ b/app/assets/javascripts/stores/SearchStore.js
@@ -12,25 +12,40 @@ var SearchActionTypes = require("../constants/SearchActionTypes");
 
 class SearchStore extends EventEmitter {
   constructor() {
-    this.baseApiUrl = "";   // Bases url to use when connecting to the Honeycomb API
-    this.collection = null; // Collection json
-    this.searchTerm = "";   // The primary search term to use when querying the API
-    this.items = [];    // Subset of items returned by the query after filtering on facet, row limit,
-                        // and starting item.
-    this.found = null;  // Total number of items that were found using the search term.
-    this.start = null;  // Start item for the query
-    this.facets = null; // List of facet options available for this collection
-    this.sorts = null;  // List of sort options available for this collection
-    this.count = 0;     // The count of items returned by the current query (<= found since items returned is a subset).
-    this.rowLimit = 12; // The maximum number of items that a query will return.
+    this._baseApiUrl = "";   // Bases url to use when connecting to the Honeycomb API
+    this._collection = null; // Collection json
+    this._searchTerm = "";   // The primary search term to use when querying the API
+    this._items = [];    // Subset of items returned by the query after filtering on facet, row limit,
+                         // and starting item.
+    this._found = null;  // Total number of items that were found using the search term.
+    this._start = null;  // Start item for the query
+    this._facets = null; // List of facet options available for this collection
+    this._sorts = null;  // List of sort options available for this collection
+    this._count = 0;     // The count of items returned by the current query (<= found since items returned is a subset).
+    this._rowLimit = 12; // The maximum number of items that a query will return.
 
     // User selections that affect the data
-    this.facetOption = null;
-    this.sortOption = null;
+    this._facetOption = null;
+    this._sortOption = null;
 
     // User selections that only affect the view (don't require a reload)
-    this.selectedItem = null;
-    this.view = null;
+    this._selectedItem = null;
+    this._view = null;
+
+    Object.defineProperty(this, "baseApiUrl", { get: function() { return this._baseApiUrl; } });
+    Object.defineProperty(this, "collection", { get: function() { return this._collection; } });
+    Object.defineProperty(this, "searchTerm", { get: function() { return this._searchTerm; } });
+    Object.defineProperty(this, "items", { get: function() { return this._items; } });
+    Object.defineProperty(this, "found", { get: function() { return this._found; } });
+    Object.defineProperty(this, "start", { get: function() { return this._start; } });
+    Object.defineProperty(this, "facets", { get: function() { return this._facets; } });
+    Object.defineProperty(this, "sorts", { get: function() { return this._sorts; } });
+    Object.defineProperty(this, "count", { get: function() { return this._count; } });
+    Object.defineProperty(this, "rowLimit", { get: function() { return this._rowLimit; } });
+    Object.defineProperty(this, "facetOption", { get: function() { return this._facetOption; } });
+    Object.defineProperty(this, "sortOption", { get: function() { return this._sortOption; } });
+    Object.defineProperty(this, "selectedItem", { get: function() { return this._selectedItem; } });
+    Object.defineProperty(this, "view", { get: function() { return this._view; } });
 
     AppDispatcher.register(this.receiveAction.bind(this));
   }
@@ -49,39 +64,39 @@ class SearchStore extends EventEmitter {
   }
 
   setQueryParams(params) {
-    this.collection = params.collection;
-    this.baseApiUrl = params.baseApiUrl;
-    this.searchTerm = params.searchTerm;
-    this.facetOption = params.facetOption;
-    this.sortOption = params.sortOption;
-    this.start = params.start;
-    this.view = params.view ? params.view : "grid";
+    this._collection = params.collection;
+    this._baseApiUrl = params.baseApiUrl;
+    this._searchTerm = params.searchTerm;
+    this._facetOption = params.facetOption;
+    this._sortOption = params.sortOption;
+    this._start = params.start;
+    this._view = params.view ? params.view : "grid";
   }
 
   getQueryParams() {
     return {
-      collection: this.collection,
-      baseApiUrl: this.baseApiUrl,
-      searchTerm: this.searchTerm,
-      facetOption: this.facetOption,
-      sortOption: this.sortOption,
-      start: this.start,
-      view: this.view,
+      collection: this._collection,
+      baseApiUrl: this._baseApiUrl,
+      searchTerm: this._searchTerm,
+      facetOption: this._facetOption,
+      sortOption: this._sortOption,
+      start: this._start,
+      view: this._view,
     };
   }
 
   executeQuery(reason) {
     reason = typeof reason != "undefined" ? reason : "load";
 
-    var url = this.baseApiUrl + "?q=" + encodeURIComponent(this.searchTerm);
-    if(this.facetOption && this.facetOption.name && this.facetOption.value) {
-      url += "&facets[" + this.facetOption.name + "]=" + this.facetOption.value;
+    var url = this._baseApiUrl + "?q=" + encodeURIComponent(this._searchTerm);
+    if(this._facetOption && this._facetOption.name && this._facetOption.value) {
+      url += "&facets[" + this._facetOption.name + "]=" + this._facetOption.value;
     }
-    if(this.sortOption) {
-      url += "&sort=" + this.sortOption;
+    if(this._sortOption) {
+      url += "&sort=" + this._sortOption;
     }
-    url += "&start=" + this.start;
-    url += "&rows=" + this.rowLimit;
+    url += "&start=" + this._start;
+    url += "&rows=" + this._rowLimit;
 
     $.ajax({
       context: this,
@@ -90,8 +105,8 @@ class SearchStore extends EventEmitter {
       dataType: "json",
       success: function(result) {
         this.setItems(result.hits);
-        this.sorts = result.sorts;
-        this.facets = result.facets;
+        this._sorts = result.sorts;
+        this._facets = result.facets;
         this.emit("SearchStoreChanged", reason);
       },
       error: function(request, status, thrownError) {
@@ -101,17 +116,17 @@ class SearchStore extends EventEmitter {
   }
 
   setTerm(term) {
-    this.searchTerm = term;
+    this._searchTerm = term;
     this.executeQuery();
   }
 
   setSelectedFacet(facet) {
-    this.facetOption = facet;
+    this._facetOption = facet;
     this.executeQuery();
   }
 
   setSelectedSort(sort) {
-    this.sortOption = sort;
+    this._sortOption = sort;
     this.executeQuery();
   }
 
@@ -131,21 +146,21 @@ class SearchStore extends EventEmitter {
   // Translates all hits to items. A hit json has a different structure from an item,
   // and most objects that interact with this store expect an item to look like an item json.
   setItems(hits) {
-    this.items = [];
-    this.found = hits.found;
-    this.start = hits.start;
+    this._items = [];
+    this._found = hits.found;
+    this._start = hits.start;
     for (var h in hits.hit) {
       if (hits.hit.hasOwnProperty(h)){
         var hit = hits.hit[h];
         var item = this.mapHitToItem(hit);
-        this.items.push(item);
+        this._items.push(item);
       }
     }
-    this.count = this.items.length;
+    this._count = this._items.length;
   }
 
   setView(view) {
-    this.view = view;
+    this._view = view;
     this.emit("SearchStoreViewChanged");
   }
 
@@ -153,21 +168,21 @@ class SearchStore extends EventEmitter {
   // This was primarily created to allow pagination to generate links using the same search, but
   // with other start values.
   searchUri(overrides) {
-    var uri = "/" + this.collection.id +
-      "/" + this.collection.slug +
-      "/search?q=" + this.searchTerm;
-    if(this.facetOption && this.facetOption.name && this.facetOption.value){
-      uri += "&facet[" + this.facetOption.name + "]=" + this.facetOption.value;
+    var uri = "/" + this._collection.id +
+      "/" + this._collection.slug +
+      "/search?q=" + this._searchTerm;
+    if(this._facetOption && this._facetOption.name && this._facetOption.value){
+      uri += "&facet[" + this._facetOption.name + "]=" + this._facetOption.value;
     }
-    if(this.sortOption) {
-      uri += "&sort=" + this.sortOption;
+    if(this._sortOption) {
+      uri += "&sort=" + this._sortOption;
     }
     if(overrides && overrides.start != "undefined") {
       uri += "&start=" + overrides.start;
-    } else if(this.start) {
-      uri += "&start=" + this.start;
+    } else if(this._start) {
+      uri += "&start=" + this._start;
     }
-    uri += "&view=" + this.view;
+    uri += "&view=" + this._view;
     return uri;
   }
 
@@ -198,13 +213,13 @@ class SearchStore extends EventEmitter {
   }
 
   getNextItem(item) {
-    for(var i = 0; i < this.items.length; ++i) {
-      if(this.items[i]["@id"] == item["@id"]) {
+    for(var i = 0; i < this._items.length; ++i) {
+      if(this._items[i]["@id"] == item["@id"]) {
         var nextI = (i + 1);
-        if(nextI > this.items.length - 1) {
+        if(nextI > this._items.length - 1) {
           return null;
         } else {
-          return this.items[nextI];
+          return this._items[nextI];
         }
       }
     }
@@ -212,13 +227,13 @@ class SearchStore extends EventEmitter {
   }
 
   getPreviousItem(item) {
-    for(var i = 0; i < this.items.length; ++i) {
-      if(this.items[i]["@id"] == item["@id"]) {
+    for(var i = 0; i < this._items.length; ++i) {
+      if(this._items[i]["@id"] == item["@id"]) {
         var prevI = i - 1;
         if(prevI < 0) {
           return null;
         } else {
-          return this.items[prevI];
+          return this._items[prevI];
         }
       }
     }


### PR DESCRIPTION
-Now that most search objects read data directly from the store, and expect the store to have the data needed by the time they render, there is no reason to propagate these values down. Cleaned up a lot of the props/state values that are now read from the store. In some cases they are still used in a state in order to trigger updates, since it's not recommended to use forceUpdate.
-Cleaned up some unused actions and unused methods in some objects.
-Pulled the row limit into the store and added this to the params when running the query. This will give us a way to change this within the store in the future. I do not have an action for this yet, since it's not needed, but I did test it out using different values and pagination and views seem to work fine with values other than the default of 12.