### PR TITLE
Collection home page layout breaks when there is no site intro

### DIFF
--- a/app/assets/javascripts/components/pages/Collection/CollectionIntro.jsx
+++ b/app/assets/javascripts/components/pages/Collection/CollectionIntro.jsx
@@ -14,13 +14,10 @@ var CollectionIntro = React.createClass({
   },
 
   render: function() {
-    if(this.props.collection && this.props.collection.short_description) {
+    if(this.props.collection) {
       return (
         <PagesShow content={this.props.collection.short_description } />
       );
-    }
-    else {
-      return null;
     }
   }
 });

--- a/app/assets/javascripts/components/pages/Pages/PagesShow.jsx
+++ b/app/assets/javascripts/components/pages/Pages/PagesShow.jsx
@@ -20,7 +20,7 @@ var PagesShow = React.createClass({
 
   render: function() {
     var pageName;
-    var pageContent = (<Loading/>);
+    var pageContent = (<div className="essay-content" />);
     if(this.props.title) {
       pageName = (<h2>{this.props.title}</h2>);
     }


### PR DESCRIPTION
-Changed PagesShow to always render a div using the correct style, instead of a Loading component. This is for when things like the CollectionIntro is blank, it will still render an empty div with the appropriate layout.
-Changed CollectionIntro to still render a PagesShow when the short_description is missing.