### PR TITLE
DEC-722: Fix Navigation Bar Search Box

### DIFF
--- a/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
+++ b/app/assets/javascripts/components/layout/CollectionPageHeader.jsx
@@ -130,7 +130,7 @@ var CollectionPageHeader = React.createClass({
     if (this.props.collection.enable_search) {
       return (
         <div style={ {float:'right', marginTop:'-8px' } }>
-          <SearchBox collection={this.props.collection} />
+          <SearchBox collection={this.props.collection} useStore={false}/>
         </div>
       );
     }

--- a/app/assets/javascripts/components/layout/SearchBox.jsx
+++ b/app/assets/javascripts/components/layout/SearchBox.jsx
@@ -8,13 +8,16 @@ var SearchActions = require("../../actions/SearchActions");
 var SearchBox = React.createClass({
   mixins: [CurrentThemeMixin],
   propTypes: {
+    collection: React.PropTypes.object,
     primary: React.PropTypes.bool,
+    useStore: React.PropTypes.bool,
   },
 
   getDefaultProps: function() {
     return {
       primary: true,
       active: false,
+      useStore: true,
     };
   },
 
@@ -31,7 +34,15 @@ var SearchBox = React.createClass({
 
   onClick: function(e) {
     if (this.state.active && this.state.searchTerm) {
-      SearchActions.setSearchTerm(this.state.searchTerm);
+      if(this.props.useStore) {
+        SearchActions.setSearchTerm(this.state.searchTerm);
+      } else {
+        var url = window.location.origin
+          + "/" + this.props.collection.id
+          + "/" + this.props.collection.slug
+          + "/search?q=" + this.state.searchTerm;
+        window.location = url;
+      }
     } else if (this.state.active) {
       this.setState({active: false});
     } else {

--- a/app/assets/javascripts/components/pages/Search/SearchControls.jsx
+++ b/app/assets/javascripts/components/pages/Search/SearchControls.jsx
@@ -77,7 +77,7 @@ var SearchControls = React.createClass({
       <div style={{height: "65px" }}>
       <mui.Toolbar className="controls" style={this.controlsStyle()}>
         <mui.ToolbarGroup key={0} float="left">
-          <SearchBox primary={false} active={true} />
+          <SearchBox primary={false} active={true} useStore={true} />
         </mui.ToolbarGroup>
         <mui.ToolbarGroup key={1} float="right">
           <MediaQuery minWidth={700}>


### PR DESCRIPTION
Problem is that SearchBox primarily uses the SearchStore now, but on all other pages it has not been initialized.

-Changed SearchBox to have two different paths, one uses the SearchStore to run the query, the other does a redirect.
-Changed CollectionPageHeader/SearchControls to specify if SearchBox should use the store or not