### PR TITLE
DEC-816: Intro card has no background

### DIFF
--- a/src/assets/css/collection.css.scss
+++ b/src/assets/css/collection.css.scss
@@ -80,7 +80,7 @@ body.collection {
 }
 
 .collection-site-path-card {
-  background-image: url("/images/intro.jpg");
+  background-image: url("../images/intro.jpg");
   background-size:cover;
   background-position:center top;
   height: 400px;

--- a/src/assets/css/collection.css.scss
+++ b/src/assets/css/collection.css.scss
@@ -79,6 +79,15 @@ body.collection {
   }
 }
 
+.collection-site-path-card {
+  background-image: url("/images/intro.jpg");
+  background-size:cover;
+  background-position:center top;
+  height: 400px;
+  overflow:hidden;
+  width:100%;
+}
+
 .start,
 .continue {
   background-color: $startbutton;

--- a/src/assets/css/collection.css.scss
+++ b/src/assets/css/collection.css.scss
@@ -81,11 +81,11 @@ body.collection {
 
 .collection-site-path-card {
   background-image: url("../images/intro.jpg");
-  background-size:cover;
-  background-position:center top;
+  background-position: center top;
+  background-size: cover;
   height: 400px;
-  overflow:hidden;
-  width:100%;
+  overflow: hidden;
+  width: 100%;
 }
 
 .start,

--- a/src/components/Collection/CollectionIntroCard.jsx
+++ b/src/components/Collection/CollectionIntroCard.jsx
@@ -18,21 +18,6 @@ var CollectionIntroCard = React.createClass({
       height: "400px",
     };
   },
-  imageSize: function() {
-    return {
-        position: 'absolute',
-        top: '0',
-        left: '0',
-        right: '0',
-        bottom: '0',
-        margin: 'auto',
-        minWidth:'50%',
-        minHeight: '50%',
-        maxWidth: 'initial',
-        maxHeight:'initial',
-        display: 'none',
-    };
-  },
 
   onClick: function(e) {
     e.preventDefault();
@@ -43,19 +28,9 @@ var CollectionIntroCard = React.createClass({
     return (
       <mui.Card onClick={this.onClick} style={this.style()} >
         <mui.CardMedia
-          mediaStyle={{
-            background:"url(/images/intro.jpg)",
-            height:'100%',
-            width:'100%',
-            backgroundSize:'cover',
-            backgroundPosition:'center top',
-          }}
-          style={{height: '400px', overflow:'hidden'}}
-          overlay={<mui.CardTitle title='Introduction'
-          rootStyle={{height:'600px'}}/>}
-          >
-          <img src='url(/images/intro.jpg)'  style={this.imageSize()} />
-        </mui.CardMedia>
+          className="collection-site-path-card"
+          overlay={<mui.CardTitle title='Introduction'/>}
+        />
       </mui.Card>
     );
   }

--- a/src/components/Collection/SitePathCard.jsx
+++ b/src/components/Collection/SitePathCard.jsx
@@ -103,11 +103,9 @@ var SitePathCard = React.createClass({
   cardMedia: function () {
     return (
       <mui.CardMedia
-        mediaStyle={{background:'url(' + this.image() + ')', height:'100%', width:'100%', backgroundSize:'cover', backgroundPosition:'center top'}}
-        className="temp"
-        style={{height: '400px', overflow:'hidden'}}
-        overlay={this.cardTitle()}>
-        <img src={this.image()}  style={this.imageSize()} />
+        className="collection-site-path-card"
+        style={{ backgroundImage:'url(' + this.image() + ')' }}
+        overlay={ this.cardTitle() }>
       </mui.CardMedia>);
   },
 


### PR DESCRIPTION
Webpack was not seeing the image as a used asset, so it was not being copied to the public/images dir. Changed these components to use a css class instead of inline style overrides. Also removed some unused styles and image nodes that weren't affecting the render.