### PR TITLE
DEC-838: Search results are not all being displayed on beehive

### DIFF
--- a/src/components/Search/SearchDisplayList.jsx
+++ b/src/components/Search/SearchDisplayList.jsx
@@ -45,7 +45,7 @@ var SearchDisplayList = React.createClass({
         <ItemListItem
           item={item}
           view={view}
-          key={item.name}
+          key={item["@id"]}
         />
       );
     });

--- a/src/layout/CollectionLeftNav.jsx
+++ b/src/layout/CollectionLeftNav.jsx
@@ -71,7 +71,7 @@ var CollectionLeftNav = React.createClass({
         <mui.MenuItem onTouchTap={() => {this.menuItemAction(aboutUrl)}} primaryText='About' key='about'/>
       ));
     }
-    options.push((<mui.Divider/>));
+    options.push((<mui.Divider key="divider"/>));
 
     if (introUrl) {
       options.push((


### PR DESCRIPTION
Fixed a key collision issue that prevented items with the same name from being rendered and removed an additional key warning for the left nav by giving the divider a key.