### PR TITLE
DEC-856: Long showcase/page names are cut off in the collection left nav drop down

### DIFF
--- a/src/assets/css/collection.css.scss
+++ b/src/assets/css/collection.css.scss
@@ -61,6 +61,14 @@ body.collection {
   }
 }
 
+.collection-left-nav-item {
+  div:last-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
 .collection-short-intro-container {
   background: rgba(244, 244, 244, 0.7);
   box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.75);

--- a/src/layout/CollectionLeftNav.jsx
+++ b/src/layout/CollectionLeftNav.jsx
@@ -83,7 +83,7 @@ var CollectionLeftNav = React.createClass({
       var url = this.collectionObjectUrl(siteObject);
       var name = siteObject.name || siteObject.name_line_1;
       options.push ((
-        <mui.MenuItem onTouchTap={() => {this.menuItemAction(url)}} primaryText={name} key={siteObject.id} />
+        <mui.MenuItem onTouchTap={() => {this.menuItemAction(url)}} primaryText={name} key={siteObject.id} className="collection-left-nav-item" />
       ));
     }.bind(this));
 


### PR DESCRIPTION
Added a class to override the lowest div in the collection left nav menu items. Would have preferred to use an inline style in the react component, but unfortunately the mui.MenuItem innerDivStyle does not set the inner most div's style.