### PR TITLE
DEC-888 Bug fix for duplicate title on showcase card

### DIFF
--- a/src/components/Collection/SitePathCard.jsx
+++ b/src/components/Collection/SitePathCard.jsx
@@ -97,7 +97,7 @@ var SitePathCard = React.createClass({
   },
 
   cardTitle: function() {
-    return (<mui.CardTitle title={this.props.siteObject.name_line_1} subtitle={this.props.siteObject.name_line_2} />);
+    return (<mui.CardTitle title={this.props.siteObject.name_line_1 || this.props.siteObject.name} subtitle={this.props.siteObject.name_line_2} />);
   },
 
   cardMedia: function () {

--- a/src/components/Collection/SitePathCard.jsx
+++ b/src/components/Collection/SitePathCard.jsx
@@ -97,7 +97,7 @@ var SitePathCard = React.createClass({
   },
 
   cardTitle: function() {
-    return (<mui.CardTitle title={this.props.siteObject.name || this.props.siteObject.name_line_1} subtitle={this.props.siteObject.name_line_2} />);
+    return (<mui.CardTitle title={this.props.siteObject.name_line_1} subtitle={this.props.siteObject.name_line_2} />);
   },
 
   cardMedia: function () {


### PR DESCRIPTION
Problem: The title for showcases was appearing twice on the showcase cards for a collection
How: The cardTitle method was doing a logical "or" on the name() and name_line_1() attributes for the showcase / siteObject. That was changed so that it will only look for the name_line_1() attribute.