### PR TITLE
DEC-1014: Fix item viewer to work with small images

### DIFF
--- a/src/components/Search/ItemPanel.jsx
+++ b/src/components/Search/ItemPanel.jsx
@@ -23,6 +23,7 @@ var ItemPanel = React.createClass({
     previousUrl: React.PropTypes.string,
     nextUrl: React.PropTypes.string,
     currentItem: React.PropTypes.string,
+    height: React.PropTypes.number,
   },
 
   getInitialState: function() {
@@ -94,8 +95,9 @@ var ItemPanel = React.createClass({
         onCloseButtonClick={this.closeButtonClick}
         onNextButtonClick={this.state.nextItem ? this.nextButtonClick : null}
         onPrevButtonClick={this.state.previousItem ? this.prevButtonClick : null}
+        height={ this.props.height }
       >
-        <ItemShow item={this.state.currentItem} />
+        <ItemShow item={this.state.currentItem} height={ this.props.height } />
       </OverlayPage>
     );
   }

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -103,7 +103,7 @@ var Search = React.createClass({
     return (
       <mui.AppCanvas>
         <CollectionPageHeader collection={SearchStore.collection} ></CollectionPageHeader>
-        <ItemPanel currentItem={this.props.currentItem}/>
+        <ItemPanel height={ window.innerHeight - 50 } currentItem={this.props.currentItem}/>
         <SearchControls searchStyle={{height:'50px'}}/>
         <PageContent fluidLayout={false}>
           <SearchDisplayList />

--- a/src/display/ItemShow.jsx
+++ b/src/display/ItemShow.jsx
@@ -39,10 +39,7 @@ var ItemShow = React.createClass({
   },
 
   render: function() {
-    var prevLink, nextLink, offsetTop;
-    if (this.props.height) {
-      offsetTop = this.props.height / 2;
-    }
+    var prevLink, nextLink;
     if (this.props.item) {
       return (
         <div style={this.outerStyles()}>
@@ -55,7 +52,7 @@ var ItemShow = React.createClass({
               <OpenseadragonViewer
                 image={this.props.item.image}
                 containerID={this.props.item.id}
-                height={this.props.height}
+                height={this.props.height - 60}
                 toolbarTop={60}
                 toolbarLeft={40}
                 showFullPageControl={false} />
@@ -64,7 +61,7 @@ var ItemShow = React.createClass({
               <OpenseadragonViewer
                 image={this.props.item.image}
                 containerID={this.props.item.id}
-                height={this.props.height}
+                height={this.props.height - 60}
                 toolbarTop={60}
                 toolbarLeft={40}
                 showFullPageControl={false}

--- a/src/display/OpenseadragonViewer.jsx
+++ b/src/display/OpenseadragonViewer.jsx
@@ -60,6 +60,7 @@ var OpenseadragonViewer = React.createClass({
     if (/^http:\/\/localhost/.test(image.contentUrl)) {
       sourceImage = this.legacySource(image);
     }
+    viewer.viewport.defaultZoomLevel = this.defaultZoom(parseInt(image.width), parseInt(image.height), window.innerWidth, this.props.height);
     viewer.open(sourceImage);
   },
 
@@ -109,6 +110,16 @@ var OpenseadragonViewer = React.createClass({
 
   },
 
+  // Use with viewport.defaultZoomLevel.
+  // If the image is larger than the viewport in width or height, returns 0 to allow
+  // the viewport to fit the image within the bounds (the default behavior). If the
+  // image is smaller than the viewport, returns a zoom that will render the image's native size.
+  defaultZoom: function(imageWidth, imageHeight, viewportWidth, viewportHeight) {
+    var widthRatio = imageWidth / viewportWidth;
+    var heightRatio = imageHeight / viewportHeight;
+    return Math.max(widthRatio, heightRatio) >= 1.0 ? 0 : widthRatio;
+  },
+
   baseOptions: function() {
     var toolbarDiv = 'toolbar-' + this.props.containerID;
     var zoomInID = 'zoom-in-' + this.props.containerID;
@@ -120,14 +131,7 @@ var OpenseadragonViewer = React.createClass({
 
     OpenSeadragon.setString("Tooltips.Home","Reset image");
 
-    var widthRatio = parseInt(this.props.image.width) / window.innerWidth;
-    var heightRatio = parseInt(this.props.image.height) / this.props.height;
-
-    var contentAspect = parseInt(this.props.image.width) / parseInt(this.props.image.height);
-    var viewportAspect = window.innerWidth / this.props.height;
-
-    var fitZoom = (contentAspect / viewportAspect); // Fit to viewport
-    var zoom = Math.max(widthRatio, heightRatio) >= 1.0 ? fitZoom : widthRatio;
+    var zoom = this.defaultZoom(parseInt(this.props.image.width), parseInt(this.props.image.height), window.innerWidth, this.props.height);
 
     return {
       id: this.props.containerID,

--- a/src/display/OpenseadragonViewer.jsx
+++ b/src/display/OpenseadragonViewer.jsx
@@ -119,11 +119,22 @@ var OpenseadragonViewer = React.createClass({
     var rightID = 'right-' + this.props.containerID;
 
     OpenSeadragon.setString("Tooltips.Home","Reset image");
+
+    var widthRatio = parseInt(this.props.image.width) / window.innerWidth;
+    var heightRatio = parseInt(this.props.image.height) / this.props.height;
+
+    var contentAspect = parseInt(this.props.image.width) / parseInt(this.props.image.height);
+    var viewportAspect = window.innerWidth / this.props.height;
+
+    var fitZoom = (contentAspect / viewportAspect); // Fit to viewport
+    var zoom = Math.max(widthRatio, heightRatio) >= 1.0 ? fitZoom : widthRatio;
+
     return {
       id: this.props.containerID,
       element: ReactDOM.findDOMNode(),
       prefixUrl: "/openseadragon/",
       autoHideControls: false,
+      defaultZoomLevel: zoom,
       showNavigator: this.props.showNavigator,
       showFullPageControl: this.props.showFullPageControl,
       navigatorHeight:   navigatorSize + 'px',
@@ -187,9 +198,13 @@ var OpenseadragonViewer = React.createClass({
   },
 
   style: function() {
+    var height = this.props.height;
+    if (this.props.showNavigator) {
+      height -= 10;
+    }
     return {
       //height: "" + (this.props.height ? this.props.height : 600) + "px",
-      height: '100vh',
+      height: height + "px",
       overflow: 'hidden',
     };
   },

--- a/src/layout/OverlayPage.jsx
+++ b/src/layout/OverlayPage.jsx
@@ -14,6 +14,7 @@ var OverlayPage = React.createClass({
     onPrevButtonClick: React.PropTypes.func,
     onNextButtonClick: React.PropTypes.func,
     onCloseButtonClick: React.PropTypes.func,
+    height: React.PropTypes.number,
   },
 
   styles: function () {
@@ -30,7 +31,7 @@ var OverlayPage = React.createClass({
 
   pageStyles: function() {
     return {
-      height: window.innerHeight + "px",
+      height: this.props.height + "px",
       width: "100%",
       position: "fixed",
       backgroundColor: this.getCurrentPallette().canvasColor,


### PR DESCRIPTION
-Fixed the overall height of the background and openseadragon viewer. Was rendering below the page.
-Changed the default zoom to use the native image size if its smaller than the viewport, and to fit to the viewport when its bigger.