### PR TITLE
DEC-1047: User's would like to see full page meta when no image is present

### DIFF
--- a/src/assets/css/ui-customizations.css.scss
+++ b/src/assets/css/ui-customizations.css.scss
@@ -82,7 +82,9 @@ body {
 }
 
 
-
+.noscroll {
+  overflow: hidden;
+}
 
 
 p {

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -33,6 +33,42 @@ var Search = React.createClass({
     currentItem: React.PropTypes.string,
   },
 
+  getInitialState: function() {
+    return {
+      windowHeight: window.innerHeight
+    };
+  },
+
+  componentWillMount: function() {
+    SearchStore.on("SearchStoreChanged", this.searchStoreChanged);
+    SearchStore.on("SearchStoreQueryFailed",
+      function(result) {
+        window.location = window.location.origin + '/404'
+      }
+    );
+    window.addEventListener("popstate", this.onWindowPopState);
+
+    if ('object' == typeof(this.props.collection)) {
+      this.setValues(this.props.collection);
+    } else {
+      this.loadRemoteCollection(this.props.collection);
+    }
+  },
+
+  componentDidMount: function() {
+    window.addEventListener('resize', this.handleResize);
+  },
+
+  componentWillUnmount: function() {
+    window.removeEventListener('resize', this.handleResize);
+  },
+
+  handleResize: function(e) {
+    this.setState({
+      windowHeight: window.innerHeight
+    });
+  },
+
   searchStoreChanged: function(reason) {
     this.setState({
       readyToRender: true,
@@ -57,22 +93,6 @@ var Search = React.createClass({
   onWindowPopState: function(event) {
     if(event.state){
       SearchActions.reloadSearchResults(event.state.store);
-    }
-  },
-
-  componentWillMount: function() {
-    SearchStore.on("SearchStoreChanged", this.searchStoreChanged);
-    SearchStore.on("SearchStoreQueryFailed",
-      function(result) {
-        window.location = window.location.origin + '/404'
-      }
-    );
-    window.addEventListener("popstate", this.onWindowPopState);
-
-    if ('object' == typeof(this.props.collection)) {
-      this.setValues(this.props.collection);
-    } else {
-      this.loadRemoteCollection(this.props.collection);
     }
   },
 
@@ -103,7 +123,7 @@ var Search = React.createClass({
     return (
       <mui.AppCanvas>
         <CollectionPageHeader collection={SearchStore.collection} ></CollectionPageHeader>
-        <ItemPanel height={ window.innerHeight - 50 } currentItem={this.props.currentItem}/>
+        <ItemPanel height={ this.state.windowHeight - 50 } currentItem={this.props.currentItem}/>
         <SearchControls searchStyle={{height:'50px'}}/>
         <PageContent fluidLayout={false}>
           <SearchDisplayList />

--- a/src/components/Showcase/SectionShow.jsx
+++ b/src/components/Showcase/SectionShow.jsx
@@ -31,14 +31,21 @@ var SectionShow = React.createClass({
 
   styles: function () {
     return {
-      backgroundColor: this.getCurrentPallette.primary3Color,
+      backgroundColor: "rgba(51,51,51,1)",
     }
   },
 
   titleStyle: function () {
     return {
-      color: this.getCurrentPallette().textColor,
+      color: this.getCurrentPallette().alternateTextColor,
       lineHeight: this.mobile() ? '24px' : '56px',
+    }
+  },
+
+  closeButtonStyle: function () {
+    return {
+      color: this.getCurrentPallette().alternateTextColor,
+      height: "100%",
     }
   },
 
@@ -66,8 +73,8 @@ var SectionShow = React.createClass({
         <mui.ToolbarGroup key={0} float="left" style={{maxWidth: this.mobile ? '80%': '90%'}}>
           <mui.ToolbarTitle text={this.title()} style={this.titleStyle()} />
         </mui.ToolbarGroup>
-        <mui.ToolbarGroup key={1} float="right">
-          <CloseButton clickEvent={this.closeDialog} />
+        <mui.ToolbarGroup key={1} float="right" style={this.closeButtonStyle()}>
+          <CloseButton clickEvent={this.closeDialog} alternate={true} />
         </mui.ToolbarGroup>
       </mui.Toolbar>
     )

--- a/src/display/Details.jsx
+++ b/src/display/Details.jsx
@@ -7,30 +7,24 @@ var MetadataList = require('../display/MetadataList.jsx');
 var Styles = {
   // The outer containing div for this component
   outer: {
-    height: "100%",
-    position: "absolute",
-    right: "70px",
-    zIndex: 100,
-    width: "350px"
+    boxShadow: "0 -5px 5px -5px rgba(0, 0, 0, 0.16), 0 -5px 5px -5px rgba(0, 0, 0, 0.23)",
+    margin: "0 auto 60px",
+    position: "relative",
+    width: "100%",
+    zIndex: 1,
   },
   // The details Paper
   details: {
     backgroundColor: "#fff",
     color: "#555",
     display: "block",
+    fontSize: "16px",
     padding: "10px",
     paddingTop: "35px",
-    position: "relative",
-    overflow: "auto",
     opacity: "0.8",
-    maxHeight: "70%",
-    top: "5px",
+    margin: "0 auto 60px",
     width: "100%",
-  },
-  // The shrink/expand details button
-  detailsButton: {
-    position: "relative",
-    left: "220",
+    maxWidth: "60em",
   },
 };
 
@@ -70,27 +64,13 @@ var Details = React.createClass({
     );
   },
 
-  detailsButton: function() {
-    return (
-      <mui.RaisedButton
-        onClick={this.toggleDetails}
-        style={ Styles.detailsButton }
-        disableTouchRipple={true}
-        label="Details"
-        labelStyle={{fontSize: "20px", letterSpacing: "0", textTransform: "uppercase", fontWeight: "500", padding: "0px 10px" }}
-      >
-        { this.arrowIcon() }
-      </mui.RaisedButton>
-    );
-  },
-
   details: function() {
     if(this.state.showDetails){
       return (
-        <mui.Paper className="item-details" style={ Styles.details }>
+        <div className="item-details" style={ Styles.details }>
           <div className="additional-details" dangerouslySetInnerHTML={{__html: this.props.additionalDetails}} />
           <MetadataList metadata={this.props.item.metadata} />
-        </mui.Paper>
+        </div>
       );
     } else {
       return null;
@@ -99,10 +79,9 @@ var Details = React.createClass({
 
   render: function () {
     return (
-      <div style={ Styles.outer }>
-        { this.detailsButton() }
+      <mui.Paper zDepth={0} style={ Styles.outer }>
         { this.details() }
-      </div>
+      </mui.Paper>
     );
   }
 });

--- a/src/display/ItemShow.jsx
+++ b/src/display/ItemShow.jsx
@@ -14,11 +14,20 @@ var ItemShow = React.createClass({
     height: React.PropTypes.number,
   },
 
+  componentWillMount: function() {
+    document.body.classList.toggle('noscroll', true);
+  },
+
+  componentWillUnmount: function() {
+    document.body.classList.toggle('noscroll', false);
+  },
+
   outerStyles: function() {
     if (this.props.height) {
       return {
         height: this.props.height,
         position: "relative",
+        overflow: "auto"
       }
     } else {
       return {}
@@ -28,8 +37,7 @@ var ItemShow = React.createClass({
   zoomStyles: function() {
     if (this.props.height) {
       return {
-        height: this.props.height,
-        position: "absolute",
+        background: "rgba(200,200,200,1)",
         top: 0,
         width: "100%",
       }
@@ -38,36 +46,49 @@ var ItemShow = React.createClass({
     }
   },
 
+  image: function() {
+    if(this.props.item.image){
+      var height = this.props.height < 500 ? this.props.height : this.props.height - 300;
+      return (
+        <div className="item-detail-zoom" style={this.zoomStyles()}>
+          <MediaQuery minWidth={650}>
+            <OpenseadragonViewer
+              image={this.props.item.image}
+              containerID={this.props.item.id}
+              height={height - 60}
+              toolbarTop={60}
+              toolbarLeft={40}
+              showFullPageControl={false} />
+          </MediaQuery>
+          <MediaQuery maxWidth={650}>
+            <OpenseadragonViewer
+              image={this.props.item.image}
+              containerID={this.props.item.id}
+              height={height - 60}
+              toolbarTop={60}
+              toolbarLeft={40}
+              showFullPageControl={false}
+              showNavigator={false} />
+          </MediaQuery>
+        </div>
+      );
+    }
+    return null;
+  },
+
+  metadata: function() {
+    return (
+      <Details item={this.props.item} additionalDetails={this.props.additionalDetails} showDetails={true} />
+    );
+  },
+
   render: function() {
     var prevLink, nextLink;
     if (this.props.item) {
       return (
         <div style={this.outerStyles()}>
-          <MediaQuery minWidth={650}>
-            <Details item={this.props.item} additionalDetails={this.props.additionalDetails} showDetails={true} />
-          </MediaQuery>
-
-          <div className="item-detail-zoom" style={this.zoomStyles()}>
-            <MediaQuery minWidth={650}>
-              <OpenseadragonViewer
-                image={this.props.item.image}
-                containerID={this.props.item.id}
-                height={this.props.height - 60}
-                toolbarTop={60}
-                toolbarLeft={40}
-                showFullPageControl={false} />
-            </MediaQuery>
-            <MediaQuery maxWidth={650}>
-              <OpenseadragonViewer
-                image={this.props.item.image}
-                containerID={this.props.item.id}
-                height={this.props.height - 60}
-                toolbarTop={60}
-                toolbarLeft={40}
-                showFullPageControl={false}
-                showNavigator={false} />
-            </MediaQuery>
-          </div>
+          { this.image() }
+          { this.metadata() }
         </div>
       );
     } else {

--- a/src/display/ItemShow.jsx
+++ b/src/display/ItemShow.jsx
@@ -12,6 +12,17 @@ var ItemShow = React.createClass({
     item: React.PropTypes.object,
     additionalDetails: React.PropTypes.string,
     height: React.PropTypes.number,
+    minMediaHeight: React.PropTypes.number, // If splitting the space between media and meta
+                                            // causes the media to go smaller than this, it
+                                            // will switch to full screen media render
+    mediaBottom: React.PropTypes.number,    // Distance from bottom of media to bottom of viewport
+  },
+
+  getDefaultProps: function() {
+    return {
+      minMediaHeight: 300,
+      mediaBottom: 200
+    }
   },
 
   componentWillMount: function() {
@@ -47,38 +58,32 @@ var ItemShow = React.createClass({
   },
 
   image: function() {
-    if(this.props.item.image){
-      var height = this.props.height < 500 ? this.props.height : this.props.height - 300;
-      return (
-        <div className="item-detail-zoom" style={this.zoomStyles()}>
-          <MediaQuery minWidth={650}>
-            <OpenseadragonViewer
-              image={this.props.item.image}
-              containerID={this.props.item.id}
-              height={height - 60}
-              toolbarTop={60}
-              toolbarLeft={40}
-              showFullPageControl={false} />
-          </MediaQuery>
-          <MediaQuery maxWidth={650}>
-            <OpenseadragonViewer
-              image={this.props.item.image}
-              containerID={this.props.item.id}
-              height={height - 60}
-              toolbarTop={60}
-              toolbarLeft={40}
-              showFullPageControl={false}
-              showNavigator={false} />
-          </MediaQuery>
-        </div>
-      );
+    var height = this.props.height - this.props.mediaBottom;
+    if( height < this.props.minMediaHeight ){
+      height = this.props.height;
     }
-    return null;
-  },
-
-  metadata: function() {
     return (
-      <Details item={this.props.item} additionalDetails={this.props.additionalDetails} showDetails={true} />
+      <div className="item-detail-zoom" style={this.zoomStyles()}>
+        <MediaQuery minWidth={650}>
+          <OpenseadragonViewer
+            image={this.props.item.image}
+            containerID={this.props.item.id}
+            height={height - 60}
+            toolbarTop={60}
+            toolbarLeft={40}
+            showFullPageControl={false} />
+        </MediaQuery>
+        <MediaQuery maxWidth={650}>
+          <OpenseadragonViewer
+            image={this.props.item.image}
+            containerID={this.props.item.id}
+            height={height - 60}
+            toolbarTop={60}
+            toolbarLeft={40}
+            showFullPageControl={false}
+            showNavigator={false} />
+        </MediaQuery>
+      </div>
     );
   },
 
@@ -87,8 +92,8 @@ var ItemShow = React.createClass({
     if (this.props.item) {
       return (
         <div style={this.outerStyles()}>
-          { this.image() }
-          { this.metadata() }
+          { this.props.item.image && this.image() }
+          <Details item={this.props.item} additionalDetails={this.props.additionalDetails} showDetails={true} />
         </div>
       );
     } else {

--- a/src/display/MetadataItem.jsx
+++ b/src/display/MetadataItem.jsx
@@ -1,5 +1,6 @@
 'use strict'
 var React = require('react');
+var mui = require('material-ui');
 
 var MetadataString = require('./MetadataString.jsx');
 var MetadataDate = require('./MetadataDate.jsx');
@@ -11,6 +12,19 @@ var fieldTypeMap = {
   MetadataDate: MetadataDate,
   MetadataHTML: MetadataHTML,
   MetadataText: MetadataText,
+};
+
+var Styles = {
+  fieldName: {
+    fontSize: "14pt"
+  },
+  fieldValue: {
+
+  },
+  divider: {
+    marginTop: "3px",
+    marginBottom: "8px"
+  }
 };
 
 var MetadataItem = React.createClass({
@@ -34,8 +48,9 @@ var MetadataItem = React.createClass({
   render: function() {
     return (
       <dl>
-        <dt>{this.props.metadata.label}</dt>
-        <dd>{this.map_arrays_to_values()}</dd>
+        <dt style={ Styles.fieldName }>{this.props.metadata.label.toUpperCase()}</dt>
+        <mui.Divider style={ Styles.divider } inset={false} />
+        <dd style={ Styles.fieldValue }>{this.map_arrays_to_values()}</dd>
       </dl>
     );
   }

--- a/src/display/OpenseadragonViewer.jsx
+++ b/src/display/OpenseadragonViewer.jsx
@@ -225,31 +225,38 @@ var OpenseadragonViewer = React.createClass({
     };
   },
 
-  render: function() {
-    var fullPageControl;
-    var toolbarID = 'toolbar-' + this.props.containerID;
-    var zoomInID = 'zoom-in-' + this.props.containerID;
-    var zoomOutID = 'zoom-out-' + this.props.containerID;
-    var homeID = 'home-' + this.props.containerID;
-    var fullID = 'full-page-' + this.props.containerID;
-    var leftID = 'left-' + this.props.containerID;
-    var rightID = 'right-' + this.props.containerID;
-    if (this.props.showFullPageControl) {
-      fullPageControl = (
-        <a id={fullID} href="#full-page"><i className="material-icons">fullscreen</i></a>
-      );
+  renderButtons: function(){
+    if(this.props.showNavigator){
+      var zoomInID = 'zoom-in-' + this.props.containerID;
+      var zoomOutID = 'zoom-out-' + this.props.containerID;
+      var homeID = 'home-' + this.props.containerID;
+      var fullID = 'full-page-' + this.props.containerID;
+      var leftID = 'left-' + this.props.containerID;
+      var rightID = 'right-' + this.props.containerID;
+
+      var nodes = [
+        <a id={zoomInID} href="#zoom-in"><i className="material-icons">zoom_in</i></a>,
+        <a id={zoomOutID} href="#zoom-out"><i className="material-icons">zoom_out</i></a>,
+        <a id={leftID} href="#rotate-left"><i className="material-icons">rotate_left</i></a>,
+        <a id={rightID} href="#rotate-right"><i className="material-icons">rotate_right</i></a>,
+        <a id={homeID} href="#home"><i className="material-icons">refresh</i></a>,
+      ];
+      if(this.props.showFullPageControl) {
+        nodes.push(<a id={fullID} href="#full-page"><i className="material-icons">fullscreen</i></a>);
+      }
+      return nodes;
     }
+    return null;
+  },
+
+  render: function() {
+    var toolbarID = 'toolbar-' + this.props.containerID;
+
     return (
       <div className="hc-openseadragon-viewer" id={this.props.containerID} style={this.style()}>
         <div id={toolbarID} className="os-toolbar" style={this.toolbarStyle()}>
-          <a id={zoomInID} href="#zoom-in"><i className="material-icons">zoom_in</i></a>
-          <a id={zoomOutID} href="#zoom-out"><i className="material-icons">zoom_out</i></a>
-          <a id={leftID} href="#rotate-left"><i className="material-icons">rotate_left</i></a>
-          <a id={rightID} href="#rotate-right"><i className="material-icons">rotate_right</i></a>
-          <a id={homeID} href="#home"><i className="material-icons">refresh</i></a>
-          {fullPageControl}
+          { this.renderButtons() }
         </div>
-        <div ></div>
       </div>
     );
   }

--- a/src/layout/OverlayPage.jsx
+++ b/src/layout/OverlayPage.jsx
@@ -19,7 +19,7 @@ var OverlayPage = React.createClass({
 
   styles: function () {
     return {
-      backgroundColor: this.getCurrentPallette.primary3Color,
+      backgroundColor: "rgba(51,51,51,1)",
       display: "block",
       overflow: "hidden"
     }
@@ -27,7 +27,7 @@ var OverlayPage = React.createClass({
 
   titleStyle: function () {
     return {
-      color: this.getCurrentPallette().textColor,
+      color: this.getCurrentPallette().alternateTextColor,
       position: "fixed",
       width: "80%"
     }
@@ -35,7 +35,8 @@ var OverlayPage = React.createClass({
 
   closeButtonStyle: function () {
     return {
-      height: "100%"
+      color: this.getCurrentPallette().alternateTextColor,
+      height: "100%",
     }
   },
 
@@ -52,8 +53,8 @@ var OverlayPage = React.createClass({
   toolbar: function() {
     return (
       <mui.Toolbar style={this.styles()} >
-        <mui.ToolbarGroup key={0} float="left"  style={this.titleStyle()}>
-          <mui.ToolbarTitle text={this.props.title} />
+        <mui.ToolbarGroup key={0} float="left">
+          <mui.ToolbarTitle text={this.props.title}  style={this.titleStyle()} />
         </mui.ToolbarGroup>
         <mui.ToolbarGroup key={1} float="right" style={this.closeButtonStyle()}>
           {this.closeButton()}
@@ -64,7 +65,7 @@ var OverlayPage = React.createClass({
 
   closeButton: function() {
     if(this.props.onCloseButtonClick) {
-      return (<CloseButton clickEvent={this.props.onCloseButtonClick} />);
+      return (<CloseButton clickEvent={this.props.onCloseButtonClick} alternate={true} />);
     }
     return "";
   },

--- a/src/layout/OverlayPage.jsx
+++ b/src/layout/OverlayPage.jsx
@@ -20,12 +20,16 @@ var OverlayPage = React.createClass({
   styles: function () {
     return {
       backgroundColor: this.getCurrentPallette.primary3Color,
+      display: "block",
+      overflow: "hidden"
     }
   },
 
   titleStyle: function () {
     return {
       color: this.getCurrentPallette().textColor,
+      position: "fixed",
+      width: "80%"
     }
   },
 
@@ -42,10 +46,10 @@ var OverlayPage = React.createClass({
   toolbar: function() {
     return (
       <mui.Toolbar style={this.styles()} >
-        <mui.ToolbarGroup key={0} float="left" >
-          <mui.ToolbarTitle text={this.props.title} style={this.titleStyle()} />
+        <mui.ToolbarGroup key={0} float="left"  style={this.titleStyle()}>
+          <mui.ToolbarTitle text={this.props.title} />
         </mui.ToolbarGroup>
-        <mui.ToolbarGroup key={1} float="right">
+        <mui.ToolbarGroup key={1} float="right" >
           {this.closeButton()}
         </mui.ToolbarGroup>
       </mui.Toolbar>

--- a/src/layout/OverlayPage.jsx
+++ b/src/layout/OverlayPage.jsx
@@ -33,6 +33,12 @@ var OverlayPage = React.createClass({
     }
   },
 
+  closeButtonStyle: function () {
+    return {
+      height: "100%"
+    }
+  },
+
   pageStyles: function() {
     return {
       height: this.props.height + "px",
@@ -49,7 +55,7 @@ var OverlayPage = React.createClass({
         <mui.ToolbarGroup key={0} float="left"  style={this.titleStyle()}>
           <mui.ToolbarTitle text={this.props.title} />
         </mui.ToolbarGroup>
-        <mui.ToolbarGroup key={1} float="right" >
+        <mui.ToolbarGroup key={1} float="right" style={this.closeButtonStyle()}>
           {this.closeButton()}
         </mui.ToolbarGroup>
       </mui.Toolbar>

--- a/src/other/CloseButton.jsx
+++ b/src/other/CloseButton.jsx
@@ -37,7 +37,7 @@ var CloseButton = React.createClass({
       <mui.EnhancedButton
         onClick={this.props.clickEvent}
         disableTouchRipple={true}
-        style={{ height: this.props.height, padding: 0 }}
+        style={{ height: "100%", padding: 0 }}
       >
         <mui.FontIcon className="material-icons" color={this.color()} style={this.iconStyle()}>clear</mui.FontIcon>
       </mui.EnhancedButton>


### PR DESCRIPTION
Why: Some items will have no image associated with it. In this case we want to render a more appropriate view when clicking on an item within search, pages, and showcases.
How: Metadata will now render at the bottom, below the image when an image is present. When there is no image, it will render fullscreen.