### PR TITLE
DEC-1035: Changing the search term or facet value while on a different page shows no results

### DIFF
--- a/src/components/Search/SearchSort.jsx
+++ b/src/components/Search/SearchSort.jsx
@@ -28,7 +28,6 @@ var SearchSort = React.createClass({
     if(window.location.search.match(regex)) {
       sortOption = window.location.search.replace(regex, '').split('&')[0];
     }
-    this.setSort(sortOption);
   },
 
   sortStyle: function() {

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -125,6 +125,8 @@ class SearchStore extends EventEmitter {
   }
 
   setTerm(term) {
+    // Reset starting item since the query has changed
+    this._start = null;
     this._searchTerm = term;
     this.executeQuery();
   }
@@ -150,13 +152,15 @@ class SearchStore extends EventEmitter {
     if(addFacet){
       this._facetOption.push(facet);
     }
-
-
+    // Reset starting item since the query has changed
+    this._start = null;
     this.executeQuery();
   }
 
   setSelectedSort(sort) {
     this._sortOption = sort;
+    // Reset starting item since the query has changed
+    this._start = null;
     this.executeQuery();
   }
 

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -104,8 +104,12 @@ class SearchStore extends EventEmitter {
     if(this._sortOption) {
       url += "&sort=" + this._sortOption;
     }
-    url += "&start=" + this._start;
-    url += "&rows=" + this._rowLimit;
+    if(this._start) {
+      url += "&start=" + this._start;
+    }
+    if(this._rowLimit) {
+      url += "&rows=" + this._rowLimit;
+    }
 
     $.ajax({
       context: this,


### PR DESCRIPTION
Changed the search store to clear the starting value anytime an action would change the resultant set of items. Also found a bug in SearchSort that was causing an extra execution of the query on page load.