### PR TITLE
DEC-1046 Add routing for custom slugs / urls

### DIFF
--- a/src/routes/CustomCollectionPage.jsx
+++ b/src/routes/CustomCollectionPage.jsx
@@ -1,0 +1,48 @@
+'use strict'
+import React, { Component, PropTypes } from 'react';
+
+import Collection from '../components/Collection/Collection.jsx';
+import HoneycombURL from '../modules/HoneycombURL.js'
+
+class CustomCollectionPage extends Component {
+
+  state = {
+      collectionResult: undefined,
+  }
+
+  componentWillMount() {
+    console.log("component will mount", this.props.params)
+    $.ajax({
+      context: this,
+      type: "GET",
+      url: HoneycombURL() + "/v1/collections/custom_slug/" + this.props.params.customSlug,
+      dataType: "json",
+      success: function(result) {
+        this.setState({
+          collectionResult: result
+        });
+      },
+      error: function(request, status, thrownError) {
+        console.log("Custom slug access not available " + thrownError);
+        window.location = window.location.origin + '/404';
+      }
+    });
+  }
+
+  render() {
+    console.log("render called");
+    console.log(this.state.collectionResult);
+    if (this.state.collectionResult) {
+      return (
+        <Collection
+          collection={ this.state.collectionResult["@id"] + "/site_path" }
+          />
+      )
+    } else {
+      return (
+      <div>Loading...</div>
+      )
+    }
+  }
+}
+export default CustomCollectionPage;

--- a/src/routes/CustomCollectionPage.jsx
+++ b/src/routes/CustomCollectionPage.jsx
@@ -11,7 +11,6 @@ class CustomCollectionPage extends Component {
   }
 
   componentWillMount() {
-    console.log("component will mount", this.props.params)
     $.ajax({
       context: this,
       type: "GET",
@@ -30,8 +29,6 @@ class CustomCollectionPage extends Component {
   }
 
   render() {
-    console.log("render called");
-    console.log(this.state.collectionResult);
     if (this.state.collectionResult) {
       return (
         <Collection

--- a/src/routes/CustomCollectionPage.jsx
+++ b/src/routes/CustomCollectionPage.jsx
@@ -2,12 +2,13 @@
 import React, { Component, PropTypes } from 'react';
 
 import Collection from '../components/Collection/Collection.jsx';
-import HoneycombURL from '../modules/HoneycombURL.js'
+import HoneycombURL from '../modules/HoneycombURL.js';
+import { browserHistory } from 'react-router';
 
 class CustomCollectionPage extends Component {
 
   state = {
-      collectionResult: undefined,
+    collectionResult: undefined,
   }
 
   componentWillMount() {
@@ -18,8 +19,10 @@ class CustomCollectionPage extends Component {
       dataType: "json",
       success: function(result) {
         this.setState({
-          collectionResult: result
-        });
+            collectionResult: result
+          },
+          browserHistory.push(result["id"] + "/" + result["slug"])
+        );
       },
       error: function(request, status, thrownError) {
         console.log("Custom slug access not available " + thrownError);
@@ -32,7 +35,7 @@ class CustomCollectionPage extends Component {
     if (this.state.collectionResult) {
       return (
         <Collection
-          collection={ this.state.collectionResult["@id"] + "/site_path" }
+          collection={ this.state.collectionResult }
           />
       )
     } else {

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -5,6 +5,7 @@ import { browserHistory, Router, Route, IndexRoute } from 'react-router';
 
 import SiteIndexPage from './SiteIndexPage.jsx';
 import CollectionPage from './CollectionPage.jsx';
+import CustomCollectionPage from './CustomCollectionPage.jsx';
 import CollectionIntroductionPage from './CollectionIntroductionPage.jsx';
 import ShowcasePage from './ShowcasePage.jsx';
 import SearchPage from './SearchPage.jsx';
@@ -30,13 +31,14 @@ export default function() {
     <Router history={ browserHistory } onUpdate={ logPageView } >
       <Route path="/" component="div">
         <IndexRoute component={ SiteIndexPage } />
+        <Route path="404" component={ErrorPage}/>
+        <Route path=":customSlug" component={CustomCollectionPage} />
         <Route path=":collectionID/*/intro" component={CollectionIntroductionPage} />
         <Route path=":collectionID/*/about" component={AboutPage} />
         <Route path=":collectionID/*/search" component={SearchPage} />
         <Route path=":collectionID/*/showcases/:showcaseID/*" component={ShowcasePage} />
         <Route path=":collectionID/*/pages/:pageID/*" component={PagesPage} />
         <Route path=":collectionID/*" component={CollectionPage} />
-        <Route path="404" component={ErrorPage}/>
       </Route>
     </Router>
   );


### PR DESCRIPTION
What: Added functionality to allow custom urls configured by the curator on the Honeycomb end
How: Created a component that can process requests that are routed using a custom url slug; Added top level route to process request; Component queries Honeycomb for collection data and routes the user to the normal collection UI and can also route to the 404 page if the slug can't be found by Honeycomb;