### PR TITLE
DEC-1061: Users would like a way to embed beehive pages

### DIFF
--- a/src/assets/css/ui-customizations.css.scss
+++ b/src/assets/css/ui-customizations.css.scss
@@ -23,6 +23,7 @@ body {
   padding-bottom: $footer-height;
   position: relative;
   color: $black;
+  background-color: $white;
 
   &.collections-bg {
 

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -20,6 +20,7 @@ var Search = React.createClass({
   ],
 
   propTypes: {
+    compact: React.PropTypes.bool,
     hits: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.array,
@@ -33,6 +34,13 @@ var Search = React.createClass({
     start: React.PropTypes.number,
     view: React.PropTypes.string,
     currentItem: React.PropTypes.string,
+  },
+
+  getDefaultProps: function() {
+    return {
+      compact: false,
+      footerHeight: 50
+    }
   },
 
   getInitialState: function() {
@@ -68,8 +76,12 @@ var Search = React.createClass({
 
   handleResize: function(e) {
     this.setState({
-      windowHeight: window.innerHeight
+      windowHeight: this.calcHeight()
     });
+  },
+
+  calcHeight: function() {
+    window.innerHeight - (this.props.compact ? this.props.footerHeight : 0);
   },
 
   searchStoreChanged: function(reason) {
@@ -83,6 +95,7 @@ var Search = React.createClass({
         currentItem = '&item=' + this.props.currentItem;
       }
       var path = window.location.origin + SearchStore.searchUri() + currentItem;
+      path += "&compact=" + this.props.compact;
       window.history.pushState({ store: SearchStore.getQueryParams() }, '', path);
     }
   },
@@ -130,13 +143,13 @@ var Search = React.createClass({
 
     return (
       <mui.AppCanvas>
-        <CollectionPageHeader collection={SearchStore.collection} ></CollectionPageHeader>
-        <ItemPanel height={ this.state.windowHeight - 50 } currentItem={this.props.currentItem}/>
+        { !this.props.compact && <CollectionPageHeader collection={SearchStore.collection} ></CollectionPageHeader> }
+        <ItemPanel height={ this.state.windowHeight } currentItem={this.props.currentItem}/>
         <SearchControls searchStyle={{height:'50px'}}/>
         <PageContent fluidLayout={false}>
           <SearchDisplayList />
         </PageContent>
-        <CollectionPageFooter collection={SearchStore.collection} />
+        { !this.props.compact && <CollectionPageFooter collection={SearchStore.collection} height={this.props.footerHeight}/> }
       </mui.AppCanvas>
     );
   }

--- a/src/components/Search/SearchPagination.jsx
+++ b/src/components/Search/SearchPagination.jsx
@@ -61,8 +61,8 @@ var SearchPagination = React.createClass({
     var startHuman = SearchStore.start + 1;
     var endHuman = Math.min(SearchStore.start + SearchStore.rowLimit, SearchStore.found);
     return (
-      <div style={{margin: '2em 0 4em', float:'right'}}>
-        <div style={{color:'rgba(0, 0, 0, 0.870588)', float: 'right', textAlign: 'right'}}>
+      <div style={{margin: '2em 0 4em'}}>
+        <div style={{color:'rgba(0, 0, 0, 0.870588)', textAlign: 'right'}}>
           <div className="pagination">
             <span style={{marginRight:'15px', display:'inline-block', verticalAlign:'top'}}>Showing {startHuman} - {endHuman} of {SearchStore.found}</span>
             {this.pageLinks()}

--- a/src/layout/CollectionPageFooter.jsx
+++ b/src/layout/CollectionPageFooter.jsx
@@ -7,13 +7,18 @@ var CollectionPageFooter = React.createClass({
 
   propTypes: {
     collection: React.PropTypes.object.isRequired,
+    height: React.PropTypes.number
+  },
+
+  getDefaultProps: function() {
+    return { height: 50 };
   },
 
   render: function () {
     return (
       <MediaQuery minWidth={650}>
-        <mui.Paper circle={false} rounded={false} zDepth={0} >
-          <footer>
+        <mui.Paper circle={false} rounded={false} zDepth={0} style={{ height: this.props.height + 'px' }}>
+          <footer style={{ height: this.props.height + 'px' }}>
             <a href="http://library.nd.edu" className="hesburgh-logo">
               Hesburgh Logo
             </a>

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -6,7 +6,6 @@ import FacetQueryParms from '../modules/FacetQueryParams.js';
 import HoneycombURL from '../modules/HoneycombURL.js'
 
 class SearchPage extends Component {
-
   render() {
     return (
       <div>
@@ -20,6 +19,7 @@ class SearchPage extends Component {
           start={QueryParm('start')}
           view={QueryParm('view')}
           currentItem={QueryParm('item')}
+          compact={ QueryParm('compact') === "true" }
         />
         {this.props.children}
       </div>


### PR DESCRIPTION
Why: Users need a way to hide headers and footers when embedding search inside of an iframe.
How:
-Changed search page to not render header/footer when query param "compact=true"
-Overrided the body color. When in compact form its possible for the facet div to overflow past the rest of the page, causing body background color to show, and all of our other divs have white backgrounds, while body was a light grey.
-Removed the magic numbers used in calculating the footer and full height.

Example iframe:
```
    <iframe src="http://localhost:3018/9e62b046bc/fighting-words/search?q=&view=list&compact=true"
      width="100%"
      height="800">
    </iframe>
```

This also restores the ability to embed items:
```
    <iframe src="http://localhost:3018/9e62b046bc/fighting-words/search?q=&view=list&item=fa6a072b64&compact=true"
      width="100%"
      height="800">
    </iframe>
```