### PR TITLE
DEC-1056 Restore state of search params on beehive

### DIFF
--- a/src/components/Search/FacetItem.jsx
+++ b/src/components/Search/FacetItem.jsx
@@ -4,13 +4,13 @@ var mui = require('material-ui');
 var ListItem = mui.ListItem;
 var FontIcon = mui.FontIcon;
 var SearchStore = require('../../store/SearchStore.js');
+var SearchActions = require('../../actions/SearchActions.js');
 
 var FacetItem = React.createClass({
 
   propTypes: {
     field: React.PropTypes.string.isRequired,
     facet: React.PropTypes.object.isRequired,
-    clickAction: React.PropTypes.func.isRequired,
   },
 
   getDefaultProps: function() {
@@ -19,9 +19,19 @@ var FacetItem = React.createClass({
     }
   },
 
-  onClick: function(e) {
-    this.props.clickAction(e);
+  valueOnClick: function(e) {
+    var values = e.currentTarget.getAttribute("value").split("|");
+    if(SearchStore.facetOption) {
+      for(var i = 0; i < SearchStore.facetOption.length; i++) {
+        if (SearchStore.facetOption[i].name === values[0] && SearchStore.facetOption[i].value === values[1]) {
+          SearchStore.removeSelectedFacet({ name: values[0], value: values[1] });
+          return
+        }
+      }
+    }
+    SearchActions.setSelectedFacet({ name: values[0], value: values[1] });
   },
+
 
   isSelected: function() {
     if(SearchStore.facetOption) {
@@ -57,7 +67,7 @@ var FacetItem = React.createClass({
         primaryText={<span style={{marginLeft:'30px', display: 'inline-block', maxWidth: 'calc(100% - 60px)'}}>{this.props.facet.name}</span>}
         secondaryText={"(" + this.props.facet.count + ")"}
         value={this.props.field +"|"+ this.props.facet.name}
-        onClick={this.onClick}
+        onClick={this.valueOnClick}
         innerDivStyle={{padding:'10px 16px'}}
         className="facet"
         leftIcon={this.leftIcon()}

--- a/src/components/Search/FacetItem.jsx
+++ b/src/components/Search/FacetItem.jsx
@@ -32,7 +32,6 @@ var FacetItem = React.createClass({
     SearchActions.setSelectedFacet({ name: values[0], value: values[1] });
   },
 
-
   isSelected: function() {
     if(SearchStore.facetOption) {
       for(var i = 0; i < SearchStore.facetOption.length; i++){

--- a/src/components/Search/FacetItem.jsx
+++ b/src/components/Search/FacetItem.jsx
@@ -1,0 +1,57 @@
+'use strict'
+var React = require('react');
+var mui = require('material-ui');
+var ListItem = mui.ListItem;
+var FontIcon = mui.FontIcon;
+var FacetItem = React.createClass({
+
+  propTypes: {
+    field: React.PropTypes.string.isRequired,
+    facet: React.PropTypes.object.isRequired,
+    isSelected: React.PropTypes.bool,
+    clickAction: React.PropTypes.func.isRequired,
+  },
+
+  getDefaultProps: function() {
+    return {
+      isSelected: false,
+    }
+  },
+
+  onClick: function(e) {
+    this.props.clickAction(e);
+  },
+
+  leftIcon: function() {
+    if(this.props.isSelected) {
+      return (<FontIcon className="material-icons" style={this.checkBoxStyle()}>check_box</FontIcon>);
+    } else {
+      return (<FontIcon className="material-icons" style={this.checkBoxStyle()}>check_box_outline_blank</FontIcon>);
+    }
+  },
+
+  checkBoxStyle: function() {
+    return {
+      fontSize: '24px',
+      top: '-6px',
+      width: '24px'
+    };
+  },
+
+  render() {
+    return (
+      <ListItem
+        key={this.props.facet.name}
+        primaryText={<span style={{marginLeft:'30px', display: 'inline-block', maxWidth: 'calc(100% - 60px)'}}>{this.props.facet.name}</span>}
+        secondaryText={"(" + this.props.facet.count + ")"}
+        value={this.props.field +"|"+ this.props.facet.name}
+        onClick={this.onClick}
+        innerDivStyle={{padding:'10px 16px'}}
+        className="facet"
+        leftIcon={this.leftIcon()}
+      />
+     );
+  }
+})
+
+export default FacetItem;

--- a/src/components/Search/FacetItem.jsx
+++ b/src/components/Search/FacetItem.jsx
@@ -29,7 +29,7 @@ var FacetItem = React.createClass({
   isSelected: function() {
     if(SearchStore.facetOption) {
       for(var i = 0; i < SearchStore.facetOption.length; i++){
-        if(encodeURIComponent(this.props.facet.name) === encodeURIComponent(decodeURIComponent(SearchStore.facetOption[i].value))) {
+        if(this.props.facet.name === decodeURIComponent(SearchStore.facetOption[i].value)) {
           return true;
         }
       }

--- a/src/components/Search/FacetItem.jsx
+++ b/src/components/Search/FacetItem.jsx
@@ -5,18 +5,11 @@ var ListItem = mui.ListItem;
 var FontIcon = mui.FontIcon;
 var SearchStore = require('../../store/SearchStore.js');
 var SearchActions = require('../../actions/SearchActions.js');
-
 var FacetItem = React.createClass({
 
   propTypes: {
     field: React.PropTypes.string.isRequired,
     facet: React.PropTypes.object.isRequired,
-  },
-
-  getDefaultProps: function() {
-    return {
-      isSelected: false,
-    }
   },
 
   valueOnClick: function(e) {
@@ -31,6 +24,7 @@ var FacetItem = React.createClass({
     }
     SearchActions.setSelectedFacet({ name: values[0], value: values[1] });
   },
+
 
   isSelected: function() {
     if(SearchStore.facetOption) {

--- a/src/components/Search/FacetItem.jsx
+++ b/src/components/Search/FacetItem.jsx
@@ -3,12 +3,13 @@ var React = require('react');
 var mui = require('material-ui');
 var ListItem = mui.ListItem;
 var FontIcon = mui.FontIcon;
+var SearchStore = require('../../store/SearchStore.js');
+
 var FacetItem = React.createClass({
 
   propTypes: {
     field: React.PropTypes.string.isRequired,
     facet: React.PropTypes.object.isRequired,
-    isSelected: React.PropTypes.bool,
     clickAction: React.PropTypes.func.isRequired,
   },
 
@@ -22,8 +23,19 @@ var FacetItem = React.createClass({
     this.props.clickAction(e);
   },
 
+  isSelected: function() {
+    if(SearchStore.facetOption) {
+      for(var i = 0; i < SearchStore.facetOption.length; i++){
+        if(encodeURIComponent(this.props.facet.name) === encodeURIComponent(decodeURIComponent(SearchStore.facetOption[i].value))) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+
   leftIcon: function() {
-    if(this.props.isSelected) {
+    if(this.isSelected()) {
       return (<FontIcon className="material-icons" style={this.checkBoxStyle()}>check_box</FontIcon>);
     } else {
       return (<FontIcon className="material-icons" style={this.checkBoxStyle()}>check_box_outline_blank</FontIcon>);

--- a/src/components/Search/SearchFacets.jsx
+++ b/src/components/Search/SearchFacets.jsx
@@ -11,14 +11,11 @@ var SearchFacets = React.createClass({
   ],
 
   values: function(facet) {
-    var parentFacet = facet.field;
     if (facet.values) {
       return (facet.values.map(function(e, index) {
-        var selectedKey;
         var selectedValue;
         if(SearchStore.facetOption) {
-          selectedKey = encodeURIComponent(SearchStore.facetOption.name);
-          if(parentFacet == selectedKey) {
+          if(facet.field == encodeURIComponent(SearchStore.facetOption.name)) {
             selectedValue = SearchStore.facetOption.value;
           }
         }

--- a/src/components/Search/SearchFacets.jsx
+++ b/src/components/Search/SearchFacets.jsx
@@ -16,31 +16,12 @@ var SearchFacets = React.createClass({
     if(SearchStore.facetOption) {
       for(var i = 0; i < SearchStore.facetOption.length; i++) {
         if (SearchStore.facetOption[i].name === values[0] && SearchStore.facetOption[i].value === values[1]) {
-          this.removeFacet(values);
+          SearchStore.removeSelectedFacet({ name: values[0], value: values[1] });
           return
         }
       }
     }
-    this.setFacet(values);
-  },
-
-  setFacet: function(values) {
     SearchActions.setSelectedFacet({ name: values[0], value: values[1] });
-  },
-
-  removeFacet: function(values) {
-    SearchStore.removeSelectedFacet({ name: values[0], value: values[1] });
-  },
-
-  isSelected: function(name) {
-    if(SearchStore.facetOption) {
-      for(var i = 0; i < SearchStore.facetOption.length; i++){
-        if(encodeURIComponent(name) === encodeURIComponent(decodeURIComponent(SearchStore.facetOption[i].value))) {
-          return true;
-        }
-      }
-    }
-    return false;
   },
 
   values: function(facet) {
@@ -59,7 +40,6 @@ var SearchFacets = React.createClass({
           <FacetItem
             field={ facet.field}
             facet={ e }
-            isSelected={ this.isSelected(e.name) }
             clickAction={ this.valueOnClick }
             key={ e.name }
           />

--- a/src/components/Search/SearchFacets.jsx
+++ b/src/components/Search/SearchFacets.jsx
@@ -2,43 +2,73 @@
 var React = require('react');
 var mui = require('material-ui');
 var List = mui.List;
-var ListItem = mui.ListItem;
 var SearchActions = require('../../actions/SearchActions.js');
 var SearchStore = require('../../store/SearchStore.js');
+var FacetItem = require('./FacetItem.jsx');
 
 var SearchFacets = React.createClass({
   mixins: [
     require('../../mixins/CurrentThemeMixin.jsx')
   ],
 
-  getInitialState: function() {
-    return {
-      selectedFacet: SearchStore.selectedFacet
-    };
-  },
-
-  facetOnClick: function(e) {
-    e.currentTarget.getAttribute("value");
-  },
-
   valueOnClick: function(e) {
     var values = e.currentTarget.getAttribute("value").split("|");
     if(SearchStore.facetOption) {
-      if (SearchStore.facetOption.name &&
-          SearchStore.facetOption.value == values[1]) {
-        this.setFacet([null, null]);
-      }
-      else {
-        this.setFacet(values);
+      for(var i = 0; i < SearchStore.facetOption.length; i++) {
+        if (SearchStore.facetOption[i].name === values[0] && SearchStore.facetOption[i].value === values[1]) {
+          this.removeFacet(values);
+          return
+        }
       }
     }
-    else {
-      this.setFacet(values);
-    }
+    this.setFacet(values);
   },
 
   setFacet: function(values) {
+    console.log('set')
     SearchActions.setSelectedFacet({ name: values[0], value: values[1] });
+  },
+
+  removeFacet: function(values) {
+    console.log('remove');
+    SearchStore.removeSelectedFacet({ name: values[0], value: values[1] });
+  },
+
+  isSelected: function(name) {
+    if(SearchStore.facetOption) {
+      for(var i = 0; i < SearchStore.facetOption.length; i++){
+        if(encodeURIComponent(name) === encodeURIComponent(decodeURIComponent(SearchStore.facetOption[i].value))) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+
+  values: function(facet) {
+    var parentFacet = facet.field;
+    if (facet.values) {
+      return (facet.values.map(function(e, index) {
+        var selectedKey;
+        var selectedValue;
+        if(SearchStore.facetOption) {
+          selectedKey = encodeURIComponent(SearchStore.facetOption.name);
+          if(parentFacet == selectedKey) {
+            selectedValue = SearchStore.facetOption.value;
+          }
+        }
+        return (
+          <FacetItem
+            field={ facet.field}
+            facet={ e }
+            isSelected={ this.isSelected(e.name) }
+            clickAction={ this.valueOnClick }
+            key={ e.name }
+          />
+        );
+      }.bind(this)));
+    }
+    return null;
   },
 
   facets: function(){
@@ -52,67 +82,6 @@ var SearchFacets = React.createClass({
         </List>
       );
     }.bind(this));
-  },
-
-  isSelected: function(name) {
-    if(this.state.selectedFacet) {
-      for(var i = 0; i < this.state.selectedFacet.length; i++){
-        if(name == this.state.selectedFacet[i].value) {
-          return true;
-        }
-      }
-    }
-    return false;
-
-  },
-
-  checkBoxStyle: function() {
-    return {
-      fontSize: '24px',
-      top: '-6px',
-      width: '24px'
-    };
-  },
-
-  values: function(facet) {
-    var parentFacet = facet.field;
-    if (facet.values) {
-      return (facet.values.map(function(e, index) {
-        var selectedKey;
-        var selectedValue;
-        if(this.state.selectedFacet) {
-          selectedKey = encodeURIComponent(this.state.selectedFacet.name);
-          if(parentFacet == selectedKey) {
-            selectedValue = this.state.selectedFacet.value;
-          }
-        }
-        return (
-          <ListItem
-            key={e.name}
-            primaryText={<span style={{marginLeft:'30px', display: 'inline-block', maxWidth: 'calc(100% - 60px)'}}>{e.name}</span>}
-            secondaryText={"(" + e.count + ")"}
-            value={parentFacet +"|"+ e.name}
-            onClick={this.valueOnClick}
-            innerDivStyle={{padding:'10px 16px'}}
-            className="facet"
-            leftIcon={this.isSelected(e.name) ?  (<mui.FontIcon className="material-icons" style={this.checkBoxStyle()}>check_box</mui.FontIcon>) :  ( <mui.FontIcon className="material-icons" style={this.checkBoxStyle()}>check_box_outline_blank</mui.FontIcon>)}
-          />
-        );
-      }.bind(this)));
-    }
-    return (<div></div>);
-  },
-
-  searchStoreChanged() {
-    this.setState({ selectedFacet: SearchStore.facetOption });
-  },
-
-  componentDidMount: function() {
-    this.searchStoreChanged();
-  },
-
-  componentWillMount: function() {
-    SearchStore.on("SearchStoreChanged", this.searchStoreChanged);
   },
 
   render: function() {

--- a/src/components/Search/SearchFacets.jsx
+++ b/src/components/Search/SearchFacets.jsx
@@ -2,7 +2,6 @@
 var React = require('react');
 var mui = require('material-ui');
 var List = mui.List;
-var SearchActions = require('../../actions/SearchActions.js');
 var SearchStore = require('../../store/SearchStore.js');
 var FacetItem = require('./FacetItem.jsx');
 
@@ -10,19 +9,6 @@ var SearchFacets = React.createClass({
   mixins: [
     require('../../mixins/CurrentThemeMixin.jsx')
   ],
-
-  valueOnClick: function(e) {
-    var values = e.currentTarget.getAttribute("value").split("|");
-    if(SearchStore.facetOption) {
-      for(var i = 0; i < SearchStore.facetOption.length; i++) {
-        if (SearchStore.facetOption[i].name === values[0] && SearchStore.facetOption[i].value === values[1]) {
-          SearchStore.removeSelectedFacet({ name: values[0], value: values[1] });
-          return
-        }
-      }
-    }
-    SearchActions.setSelectedFacet({ name: values[0], value: values[1] });
-  },
 
   values: function(facet) {
     var parentFacet = facet.field;
@@ -40,7 +26,6 @@ var SearchFacets = React.createClass({
           <FacetItem
             field={ facet.field}
             facet={ e }
-            clickAction={ this.valueOnClick }
             key={ e.name }
           />
         );

--- a/src/components/Search/SearchFacets.jsx
+++ b/src/components/Search/SearchFacets.jsx
@@ -25,12 +25,10 @@ var SearchFacets = React.createClass({
   },
 
   setFacet: function(values) {
-    console.log('set')
     SearchActions.setSelectedFacet({ name: values[0], value: values[1] });
   },
 
   removeFacet: function(values) {
-    console.log('remove');
     SearchStore.removeSelectedFacet({ name: values[0], value: values[1] });
   },
 

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -150,7 +150,7 @@ class SearchStore extends EventEmitter {
     }
     // should we add the facet, start by assuming yes we should
     var addFacet = true;
-    // look for a facet wit the same name
+    // look for a facet with the same name
     // if it is found, delete it
     // if it has the same name and same value, we don't want to add it so
     // set addFacet to false

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -171,12 +171,10 @@ class SearchStore extends EventEmitter {
   }
 
   removeSelectedFacet(facet) {
-    console.log('rsf', this._facetOption, facet);
     for (var i = 0; i < this._facetOption.length; i++) {
       if(this._facetOption[i].name === facet.name){
         if(this._facetOption[i].value === facet.value) {
           this._facetOption.splice(i, 1);
-          console.log('remove', this._facetOption, 'remove');
           this._start = null;
           this.executeQuery();
         }

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -156,7 +156,7 @@ class SearchStore extends EventEmitter {
     // set addFacet to false
     for (var i = 0; i < this._facetOption.length; i++) {
       if(this._facetOption[i].name == facet.name){
-        if(this._facetOption[i].value == facet.value) {
+        if(this._facetOption[i].value == encodeURIComponent(facet.value)) {
           addFacet = false;
         }
         this._facetOption.splice(i, 1);
@@ -168,6 +168,20 @@ class SearchStore extends EventEmitter {
     // Reset starting item since the query has changed
     this._start = null;
     this.executeQuery();
+  }
+
+  removeSelectedFacet(facet) {
+    console.log('rsf', this._facetOption, facet);
+    for (var i = 0; i < this._facetOption.length; i++) {
+      if(this._facetOption[i].name === facet.name){
+        if(this._facetOption[i].value === facet.value) {
+          this._facetOption.splice(i, 1);
+          console.log('remove', this._facetOption, 'remove');
+          this._start = null;
+          this.executeQuery();
+        }
+      }
+    }
   }
 
   setSelectedSort(sort) {


### PR DESCRIPTION
Described problem: 
Not sure when this broke, but if you load a url on beehive that has search params specified, such as facets, sort, q, etc, these will not be reflected in the UI. Ex, if a q=term is specified, that term should be populated in the search box, if facet[field]=value is specified, that facet should be checked off, etc.

Observed problem:
It currently only looks like the facets are broken. Search term, sort order, and list display all seem to work fine.

Solution:
* Added proper remove facet functionality to SearchStore
* Split monolithic SearchFacets into SearchFacets and FacetItem components
* Fixed a few places where comparisons were being made between uri encoded strings being compared to non-encoded strings
* Removed selectedFacet state and rely on store instead for data updates