### PR TITLE
DEC-1095

### DIFF
--- a/src/components/Showcase/SectionShow.jsx
+++ b/src/components/Showcase/SectionShow.jsx
@@ -32,6 +32,7 @@ var SectionShow = React.createClass({
   styles: function () {
     return {
       backgroundColor: "rgba(51,51,51,1)",
+      overflow: 'hidden',
     }
   },
 


### PR DESCRIPTION
* Items with very long names not displaying properly in Beehive (See
After Gutenberg>Sebastian Franck, Weltbuch ...

* Fixed by adding overflow:hidden to titlebar style.