### PR TITLE
DEC-1158: Render Media

### DIFF
--- a/src/components/Search/ItemImage.jsx
+++ b/src/components/Search/ItemImage.jsx
@@ -36,13 +36,10 @@ var ItemImage = React.createClass({
   },
 
   image: function() {
-    if(this.props.item.image) {
-      return this.props.item.image["thumbnail/medium"].contentUrl;
-    } else if (this.props.item.multimedia) {
-      return this.props.item.multimedia.thumbnailUrl;
-    } else {
+    if(this.props.item.thumbnailURL)
+      return this.props.item.thumbnailURL;
+    else
       return "/images/meta-only-item.jpg";
-    }
   },
 
   render: function() {

--- a/src/components/Showcase/ImageCard.jsx
+++ b/src/components/Showcase/ImageCard.jsx
@@ -18,7 +18,7 @@ var ImageCard = React.createClass({
     return (
       <div style={this.style()}>
         <mui.CardMedia className="img">
-          <img style={{width: 'auto' }} src={this.props.section.item.image['thumbnail/medium'].contentUrl} />
+          <img style={{width: 'auto' }} src={this.props.section.item.media['thumbnail/medium'].contentUrl} />
         </mui.CardMedia>
         <CardCaption caption={this.props.section.caption} />
       </div>

--- a/src/components/Showcase/SectionCard.jsx
+++ b/src/components/Showcase/SectionCard.jsx
@@ -41,7 +41,7 @@ var SectionCard = React.createClass({
 
   sectionType: function() {
     if (this.props.section.item) {
-      if(this.props.section.item.image){
+      if(this.props.section.item.media){
         return "image";
       }
       else if(this.props.section.item.multimedia){

--- a/src/display/ItemShow.jsx
+++ b/src/display/ItemShow.jsx
@@ -57,9 +57,10 @@ var ItemShow = React.createClass({
       return {}
     }
   },
+
   multimedia: function() {
     var height;
-    if(this.props.item.multimedia["@type"] === "AudioObject") {
+    if(this.props.item.media["@type"] === "AudioObject") {
       height = 40;
     }
     else  {
@@ -72,13 +73,14 @@ var ItemShow = React.createClass({
     return (
       <div className="item-detail-zoom" style={this.zoomStyles()}>
         <MultimediaViewer
-          url={ this.props.item.multimedia.embedUrl }
+          url={ this.props.item.media.embedUrl }
           autostart={ true }
           height={ height + "px" }
         />
       </div>
     );
   },
+
   image: function() {
     var height = this.props.height - this.props.mediaBottom;
     if( height < this.props.minMediaHeight ){
@@ -88,7 +90,7 @@ var ItemShow = React.createClass({
       <div className="item-detail-zoom" style={this.zoomStyles()}>
         <MediaQuery minWidth={650}>
           <OpenseadragonViewer
-            image={this.props.item.image}
+            image={this.props.item.media}
             containerID={this.props.item.id}
             height={height - 60}
             toolbarTop={60}
@@ -97,7 +99,7 @@ var ItemShow = React.createClass({
         </MediaQuery>
         <MediaQuery maxWidth={650}>
           <OpenseadragonViewer
-            image={this.props.item.image}
+            image={this.props.item.media}
             containerID={this.props.item.id}
             height={height - 60}
             toolbarTop={60}
@@ -111,23 +113,28 @@ var ItemShow = React.createClass({
 
   render: function() {
     var prevLink, nextLink;
-    if (this.props.item && this.props.item.image) {
-      return (
-        <div style={this.outerStyles()}>
-          { this.props.item.image && this.image() }
-          <Details item={this.props.item} additionalDetails={this.props.additionalDetails} showDetails={true} />
-        </div>
-      );
-    } else if (this.props.item && this.props.item.multimedia) {
-      return (
-        <div style={this.outerStyles()}>
-          { this.props.item.multimedia && this.multimedia() }
-          <Details item={this.props.item} additionalDetails={this.props.additionalDetails} showDetails={true} />
-        </div>
-      );
-    } else {
-      return <Loading />;
+    if (this.props.item && this.props.item.media != null){
+      if(this.props.item.media["@type"] == "ImageObject") {
+        return (
+          <div style={this.outerStyles()}>
+            { this.image() }
+            <Details item={this.props.item} additionalDetails={this.props.additionalDetails} showDetails={true} />
+          </div>
+        );
+      } else if (this.props.item.media["@type"] == "AudioObject" || this.props.item.media["@type"] == "VideoObject") {
+        return (
+          <div style={this.outerStyles()}>
+            { this.multimedia() }
+            <Details item={this.props.item} additionalDetails={this.props.additionalDetails} showDetails={true} />
+          </div>
+        );
+      }
     }
+    return (
+      <div style={this.outerStyles()}>
+        <Details item={this.props.item} additionalDetails={this.props.additionalDetails} showDetails={true} />
+      </div>
+    );
   }
 });
 

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -17,8 +17,8 @@ class SearchStore extends EventEmitter {
     this._baseApiUrl = "";   // Bases url to use when connecting to the Honeycomb API
     this._collection = null; // Collection json
     this._searchTerm = "";   // The primary search term to use when querying the API
-    this._items = [];    // Subset of items returned by the query after filtering on facet, row limit,
-                         // and starting item.
+    this._items = [];    // Subset of item hits returned by the query after filtering on facet, row limit,
+                         // and starting item. Note, these are search hits, not complete item objects
     this._found = null;  // Total number of items that were found using the search term.
     this._start = null;  // Start item for the query
     this._facets = null; // List of facet options available for this collection
@@ -187,13 +187,7 @@ class SearchStore extends EventEmitter {
     item.name = hit.name;
     item.description = hit.description;
     item.shortDescription = hit.shortDescription;
-    if(hit.thumbnailURL){
-      item.image = {
-        "thumbnail/medium": {
-          contentUrl: hit.thumbnailURL
-        }
-      };
-    };
+    item.thumbnailURL = hit.thumbnailURL;
     return item;
   }
 
@@ -203,13 +197,7 @@ class SearchStore extends EventEmitter {
     this._items = [];
     this._found = hits.found;
     this._start = hits.start;
-    for (var h in hits.hit) {
-      if (hits.hit.hasOwnProperty(h)){
-        var hit = hits.hit[h];
-        var item = this.mapHitToItem(hit);
-        this._items.push(item);
-      }
-    }
+    this._items = hits.hit;
     this._count = this._items.length;
   }
 


### PR DESCRIPTION
-Honeycomb now renders a "media" object with a type instead of an "image" or "multimedia" object. Changed the renderers to support this
-Also fixed a few problems with mapping hits to items in the search store. Hits always have thumbnails, regardless of type, so we don't need to do this mapping. I'd also prefer this not give the illusion that it is an item, when it actually is just a hit.