### PR TITLE
Media in showcases

### DIFF
--- a/src/components/Showcase/ImageCard.jsx
+++ b/src/components/Showcase/ImageCard.jsx
@@ -18,7 +18,7 @@ var ImageCard = React.createClass({
     return (
       <div style={this.style()}>
         <mui.CardMedia className="img">
-          <img style={{width: 'auto' }} src={this.props.section.item.media['thumbnail/medium'].contentUrl} />
+          <img style={{width: 'auto' }} src={this.props.section.item.media.thumbnailUrl} />
         </mui.CardMedia>
         <CardCaption caption={this.props.section.caption} />
       </div>


### PR DESCRIPTION
All media will now have a thumbnailUrl at the base object. Changed the ImageCard to read this instead of the honeypot derivative