### PR TITLE
default continue button image broken

### DIFF
--- a/src/assets/css/ui-customizations.css.scss
+++ b/src/assets/css/ui-customizations.css.scss
@@ -267,7 +267,7 @@ body .jumbotron, .container .jumbotron, .container-fluid .jumbotron {
     box-shadow: 0 0 8px 4px rgba(31, 31, 31, 0.4);
   }
 
-  img[src="/images/blank.png"] {
+  img[src="/images/intro.jpg"] {
     border: none;
     box-shadow: none;
   }

--- a/src/other/HoneycombImage.jsx
+++ b/src/other/HoneycombImage.jsx
@@ -27,7 +27,7 @@ var HoneycombImage = React.createClass({
         return this.props.image.contentUrl;
       }
     } else {
-      return '/images/blank.png';
+      return '/images/intro.jpg';
     }
   },
 


### PR DESCRIPTION
There was reference to '/images/blank.png' which didn't exist. Instead, I've changed it to use '/images/intro.jpg' which is used elsewhere as the default image. Conformity and non-broken links!