### PR TITLE
Bugfix for Search history bug

### DIFF
--- a/src/components/Search/ItemPanel.jsx
+++ b/src/components/Search/ItemPanel.jsx
@@ -34,6 +34,15 @@ var ItemPanel = React.createClass({
     };
   },
 
+  componentWillReceiveProps: function(newProps){
+    if(newProps.currentItem && newProps.currentItem !== this.state.currentItem){
+      var url = HoneycombURL() + '/v1/items/' + newProps.currentItem;
+      this.loadRemoteItem(url);
+    } else {
+      this.removeCurrentItem();
+    }
+  },
+
   componentWillMount: function() {
     EventEmitter.on("ItemDialogWindow", this.setCurrentItem);
     EventEmitter.on("HideItemDialogWindow", this.removeCurrentItem);
@@ -51,7 +60,6 @@ var ItemPanel = React.createClass({
       nextItem: nextItem,
       previousItem: previousItem,
     });
-    OpenItemDisplay(this.state.currentItem.id);
   },
 
   removeCurrentItem: function() {
@@ -66,8 +74,8 @@ var ItemPanel = React.createClass({
     var searchStr = window.location.search;
     var removeStr = '&item=' + this.state.currentItem.id;
     searchStr = searchStr.replace(removeStr, '');
-    history.pushState({}, '', path + searchStr);
     this.removeCurrentItem();
+    history.pushState({}, '', path + searchStr);
   },
 
   nextButtonClick: function() {

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -96,7 +96,6 @@ var Search = React.createClass({
       }
       var path = window.location.origin + SearchStore.searchUri() + currentItem;
       path += "&compact=" + this.props.compact;
-      window.history.pushState({ store: SearchStore.getQueryParams() }, '', path);
     }
   },
 
@@ -112,8 +111,10 @@ var Search = React.createClass({
   },
 
   onWindowPopState: function(event) {
-    if(event.state){
+    if(event.state.store){
       SearchActions.reloadSearchResults(event.state.store);
+    } else {
+      this.forceUpdate();
     }
   },
 

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -96,6 +96,8 @@ var Search = React.createClass({
       }
       var path = window.location.origin + SearchStore.searchUri() + currentItem;
       path += "&compact=" + this.props.compact;
+      window.history.replaceState({ store: SearchStore.getQueryParams() }, '', path);
+
     }
   },
 
@@ -113,9 +115,7 @@ var Search = React.createClass({
   onWindowPopState: function(event) {
     if(event.state.store){
       SearchActions.reloadSearchResults(event.state.store);
-    } else {
-      this.forceUpdate();
-    }
+    } 
   },
 
   // Translates the facet option given in props to the structure the SearchStore expects.


### PR DESCRIPTION
This fixes a problem where users were unable to navigate forward/back in the browser after clicking on items within the search results.

Summary of changes:
- Added a componentWillReceiveProps on ItemPanel. This will be called anytime the react router re-renders the same page, ex: when the person clicks forward/back but stays within /search. ItemPanel will use this to re-render based on the item from the history.
- Search was duplicating histories on the initial load after the search finished running. Changed to replace the existing state in the history.