### PR TITLE
DEC-1209 Left nav bar not being populated

### DIFF
--- a/src/layout/CollectionLeftNav.jsx
+++ b/src/layout/CollectionLeftNav.jsx
@@ -23,8 +23,20 @@ var CollectionLeftNav = React.createClass({
     };
   },
 
+  componentWillMount: function() {
+    if (this.props.collection['site_path']) {
+      this.setState({
+        sitePath: this.props.collection['site_path']
+      });
+    }
+  },
+
   componentDidMount: function() {
+    if (this.props.collection['site_path']) {
+      return;
+    }
     var url = this.props.collection['@id'] + '/site_path';
+
     $.ajax({
       context: this,
       type: "GET",


### PR DESCRIPTION
As far as I can tell (haven't dug into how ajax works internally) two queries fetching the same resource were conflicting with one another, one would complete and cause the other to not fire success/error callbacks. 

As the second query is not needed in this case, I now use the data already present instead of asking for it again, gaining both speed and correct results. 
