### PR TITLE
DEC-1281

### DIFF
--- a/src/components/Pages/Page.jsx
+++ b/src/components/Pages/Page.jsx
@@ -30,6 +30,7 @@ var Page = React.createClass({
 
   getInitialState: function() {
     return {
+      titleHeight: 56,
       currentItem: null,
       titleSectionPercentVisible: 0,
     };
@@ -152,7 +153,7 @@ var Page = React.createClass({
         <OverlayPage title={this.state.currentItem.name} onCloseButtonClick={this.closeItem}
           onNextButtonClick={this.state.currentItem.nextItem ? this.nextButtonClick : null}
           onPrevButtonClick={this.state.currentItem.previousItem ? this.prevButtonClick : null}>
-          <ItemShow item={this.state.currentItem} height={window.innerHeight - 35} onClose={this.closeItem}/>
+          <ItemShow item={this.state.currentItem} height={window.innerHeight - this.state.titleHeight} onClose={this.closeItem} />
         </OverlayPage>
       );
     }
@@ -186,11 +187,9 @@ var Page = React.createClass({
 
     return (
       <mui.AppCanvas>
-        <CollectionPageHeader collection={this.state.collection} branding={false}>
-          <PageTitleBar title={this.state.collection.pages.name} height={35}/>
-        </CollectionPageHeader>
+        <CollectionPageHeader collection={this.state.collection} branding={false} />
+        <PageTitleBar title={this.state.collection.pages.name} height={this.state.titleHeight} />
           { this.renderItem() }
-          <div id="TitleSpacer" style={{ height: 35, width: "100%" }} />
           <PageContent onClick={this.contentClicked} onMouseOver={this.contentMouseOver}>
             <PagesShow content={this.pageContent()}>
               { this.nextCard() }

--- a/src/components/Pages/PageTitleBar.jsx
+++ b/src/components/Pages/PageTitleBar.jsx
@@ -32,8 +32,6 @@ var PageTitleBar = React.createClass({
 
   style: function() {
     return {
-      position: "fixed",
-      top: this.getCurrentTheme().appBar.height + 1 + "px",
       height: this.props.height + "px",
       opacity: this.state.opacity,
       backgroundColor: "rgba(51,51,51,1)",
@@ -60,6 +58,7 @@ var PageTitleBar = React.createClass({
   closeButtonStyle: function() {
     return {
       marginLeft: 'auto',
+      height: "100%",
     };
   },
 


### PR DESCRIPTION
The header of showcases was laid out differently than that of showcases. This will make them appear the same.

There is an argument that this could be a much larger ticket to make all pages be generated with the same codepath. I would agree that this should happen, but with my brief perusal of the code that seems like a task that should be planned out. As it stands, there is quite a bit of code duplication in the different page type generation.
