### PR TITLE
DEC-1280

### DIFF
--- a/src/components/Showcase/ShowcaseShow.jsx
+++ b/src/components/Showcase/ShowcaseShow.jsx
@@ -7,7 +7,7 @@ var ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 var MediaQuery = require('react-responsive');
 
 var maxShowcaseHeight = 805;
-var showcaseTitleHeight = 35;
+var showcaseTitleHeight = 56;
 var scrollPadding = 80;
 var titleSectionWidthPercent = 0.85;
 var minBackgroundBlur = 0.3;

--- a/src/display/Details.jsx
+++ b/src/display/Details.jsx
@@ -40,7 +40,8 @@ var Details = React.createClass({
 
   getDefaultProps: function() {
     return {
-      showDetails: true
+      showDetails: true,
+      printable: true,
     }
   },
 
@@ -69,7 +70,7 @@ var Details = React.createClass({
       return (
         <div className="item-details" style={ Styles.details }>
           <div className="additional-details" dangerouslySetInnerHTML={{__html: this.props.additionalDetails}} />
-          <MetadataList metadata={this.props.item.metadata} />
+          <MetadataList metadata={this.props.item.metadata} id={this.props.item.id} printable={this.props.printable} />
         </div>
       );
     } else {

--- a/src/display/MetadataList.jsx
+++ b/src/display/MetadataList.jsx
@@ -1,12 +1,20 @@
 'use strict'
 var React = require('react');
 var MetadataItem = require('./MetadataItem.jsx');
+var mui = require('material-ui');
 var ConfigurationStore = require("../store/ConfigurationStore.js");
 
 var MetadataList = React.createClass({
 
   propTypes: {
     metadata: React.PropTypes.object.isRequired,
+    id: React.PropTypes.string.isRequired,
+  },
+
+  getDefaultProps: function() {
+    return {
+      printable: true,
+    }
   },
 
   componentWillMount: function(){
@@ -41,10 +49,22 @@ var MetadataList = React.createClass({
     }.bind(this));
   },
 
+  printable: function() {
+    if(this.props.printable) {
+      var url = "/metadata/" + this.props.id;
+      return (
+        <a href={url} target="_blank"><mui.FontIcon className="material-icons">print</mui.FontIcon>Printer Friendly View</a>
+      );
+    } else {
+      return (<div/>);
+    }
+  },
+
   render: function() {
     return (
       <div className="metadata-list">
         { this.metadataNodes() }
+        { this.printable() }
       </div>
     );
   }

--- a/src/routes/PrintableMetadata.jsx
+++ b/src/routes/PrintableMetadata.jsx
@@ -1,0 +1,38 @@
+'use strict'
+var React = require('react');
+var mui = require('material-ui');
+
+var EventEmitter = require('../middleware/EventEmitter.js');
+var HoneycombURL = require('../modules/HoneycombURL.js');
+var Details = require('../display/Details.jsx');
+
+var PrintableMetadata = React.createClass({
+  mixins: [
+    require("../mixins/LoadRemoteMixin.jsx"),
+    require("../mixins/MuiThemeMixin.jsx")
+  ],
+
+  componentWillMount: function() {
+    EventEmitter.on("ItemDialogWindow", this.setItem);
+    var url = HoneycombURL() + '/v1/items/' + this.props.params.itemID;
+    this.loadRemoteItem(url);
+  },
+
+  setItem: function(item) {
+    this.setState({
+      item: item,
+    });
+  },
+
+  render: function() {
+    if(this.state.item) {
+      return (
+        <Details item={this.state.item} showDetails={true} printable={false} />
+      );
+    } else {
+      return (<div/>);
+    }
+  }
+});
+
+export default PrintableMetadata;

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -12,6 +12,7 @@ import SearchPage from './SearchPage.jsx';
 import ErrorPage from './ErrorPage.jsx';
 import AboutPage from './AboutPage.jsx';
 import PagesPage from './PagesPage.jsx';
+import PrintableMetadata from './PrintableMetadata.jsx';
 
 var ga = require('react-ga');
 ga.initialize('UA-2118378-44');
@@ -32,6 +33,7 @@ export default function() {
       <Route path="/" component="div">
         <IndexRoute component={ SiteIndexPage } />
         <Route path="404" component={ErrorPage}/>
+        <Route path="metadata/:itemID" component={PrintableMetadata} />
         <Route path=":customSlug" component={CustomCollectionPage} />
         <Route path=":collectionID/*/intro" component={CollectionIntroductionPage} />
         <Route path=":collectionID/*/about" component={AboutPage} />


### PR DESCRIPTION
Printing an item page was not printer friendly, it would try to print both the background and foreground over one another.

As a (probably not) temporary solution, I've added a "Printer Friendly View" button to the bottom of metadata which opens a new tab containing only the metadata for that item. This new tab has a clean, printable view.