### PR TITLE
DEC-1289 Metadata print ordering

### DIFF
--- a/src/routes/PrintableMetadata.jsx
+++ b/src/routes/PrintableMetadata.jsx
@@ -5,6 +5,8 @@ var mui = require('material-ui');
 var EventEmitter = require('../middleware/EventEmitter.js');
 var HoneycombURL = require('../modules/HoneycombURL.js');
 var Details = require('../display/Details.jsx');
+var ConfigurationActions = require("../actions/ConfigurationActions.js");
+var ConfigurationStore = require("../store/ConfigurationStore.js");
 
 var PrintableMetadata = React.createClass({
   mixins: [
@@ -13,6 +15,7 @@ var PrintableMetadata = React.createClass({
   ],
 
   componentWillMount: function() {
+    ConfigurationStore.addChangeListener(this.configurationLoaded);
     EventEmitter.on("ItemDialogWindow", this.setItem);
     var url = HoneycombURL() + '/v1/items/' + this.props.params.itemID;
     this.loadRemoteItem(url);
@@ -22,10 +25,25 @@ var PrintableMetadata = React.createClass({
     this.setState({
       item: item,
     });
+
+    if(item["isPartOf/collection"]) {
+      var collectionUrl = item["isPartOf/collection"];
+      this.loadRemoteCollection(collectionUrl);
+    } else {
+      this.setState({ "configurationLoaded": true });
+    }
+  },
+
+  setValues: function(result) {
+    ConfigurationActions.load(result);
+  },
+
+  configurationLoaded: function(){
+    this.setState({ configurationLoaded: true });
   },
 
   render: function() {
-    if(this.state.item) {
+    if(this.state.item && this.state.configurationLoaded) {
       return (
         <Details item={this.state.item} showDetails={true} printable={false} />
       );


### PR DESCRIPTION
Initially, the print page for metadata wasn't loading the collections configuration so the rows weren't ordered. Changing this requires loading the collection and then the configuration, but now everything is ordered correctly!