### PR TITLE
DEC-1425 Fix browse collection link issue

### DIFF
--- a/src/layout/CollectionPageHeader.jsx
+++ b/src/layout/CollectionPageHeader.jsx
@@ -108,6 +108,7 @@ const CollectionPageHeader = createReactClass({
   },
 
   tabs: function () {
+    ConfigurationActions.load(this.props.collection)
     const availableTabs = this.availableTabs()
     if (availableTabs.length > 0) {
       return (


### PR DESCRIPTION
* Make sure the title bar is loading about and browse tabs for the
correct collection instead of relying on an old value.