### PR TITLE
Fix close button to work correctly on the search page.

### DIFF
--- a/src/other/CloseButton.jsx
+++ b/src/other/CloseButton.jsx
@@ -37,10 +37,12 @@ const CloseButton = createReactClass({
 
     // go back to the search page if we have search information in the store
     if (SearchStore.collection) {
-      return {
-        pathname: SearchStore.searchPath(),
-        query: SearchStore.searchQuery(),
+      let searchQuery = SearchStore.searchQuery()
+      let queryString = '?'
+      for (let key in searchQuery) {
+        queryString += `${key}=${searchQuery[key]}&`
       }
+      return `${SearchStore.searchPath()}${queryString}`
     }
 
     let current = window.location.pathname


### PR DESCRIPTION
We are no longer pushing to the history to navigate, so instead of returning a route object, we need to return a string path.