### PR TITLE
INC0164038

### DIFF
--- a/src/components/SiteIndex/CollectionCard.jsx
+++ b/src/components/SiteIndex/CollectionCard.jsx
@@ -113,15 +113,30 @@ const CollectionCard = createReactClass({
     return { color: '#d9a91b' }
   },
 
+  collectionLink: function () {
+    if (this.props.collection.external_url) {
+      return (
+        <a href={CollectionUrl.collectionUrl(this.props.collection)}>
+          {this.headerTitle()}
+          {this.cardMedia()}
+          {this.cardTitle()}
+        </a>
+      )
+    }
+    return (
+      <Link to={CollectionUrl.collectionUrl(this.props.collection)}>
+        {this.headerTitle()}
+        {this.cardMedia()}
+        {this.cardTitle()}
+      </Link>
+    )
+  },
+
   render: function () {
     return (
 
       <Card style={this.style()} >
-        <Link to={CollectionUrl.collectionUrl(this.props.collection)}>
-          {this.headerTitle()}
-          {this.cardMedia()}
-          {this.cardTitle()}
-        </Link>
+        {this.collectionLink()}
         <CardActions style={this.actionButtonsStyle()} >
           <FlatButton
             label='Explore'


### PR DESCRIPTION
Issue: When an external collection is added to HoneyComb, the resulting tile has one link that works (the "EXPLORE" text below the image) and one link that does not work (the image itself).

Solution: Use `<a/>` instead of `<Link/>` for collections that have an external_url