### PR TITLE
Fix bug on search page that returns no results by default

### DIFF
--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -13,7 +13,7 @@ class SearchPage extends Component {
           collection={HoneycombURL() + '/v1/collections/' +
             this.props.match.params.collectionID}
           hits={HoneycombURL() + '/v1/collections/' + this.props.match.params.collectionID + '/search'}
-          searchTerm={QueryParm('q')}
+          searchTerm={QueryParm('q') || ''}
           sortTerm={QueryParm('sort')}
           facet={FacetQueryParms()}
           start={parseInt(QueryParm('start'), 10)}


### PR DESCRIPTION
**Issue:**

* `http://collections.library.nd.edu/<ID>/<Title>/search?q=` returns all results by default and is the url linked to the search/browse button.

* `http://collections.library.nd.edu/<ID>/<Title>/search` returns no results by default.

* Google ignores query parameters on a url and is probably trying to hit `search` instead of `search?q=` even though the `?q=` version of the url one is linked in the UI.

**Fix:**

* Default to empty search when `?q=` is absent.


