### PR TITLE
Allow configuration through env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,30 @@
 Beehive provides an attractive frontend display for the collections and exhibits created and managed by [Honeycomb](https://github.com/ndlib/honeycomb).
 It is created and managed by WSE at Hesburgh Libraries.
 
-### Installation ###
+## Installation
+
 1. `yarn install`
 
-### Usage ###
+## Running a Development Server
+
 1. `yarn start`
 
-### Deployment - UA/Prep ###
-* `aws-vault exec libnd ./deploy-pprd.sh`
+## Deployment
 
-### Deployment - Production ###
+### UA/Prep
+
+* `aws-vault exec libnd ./deploy-prep.sh`
+
+### Production
+
 * `aws-vault exec libnd ./deploy-prod.sh`
+
+### Building for a different stage
+
+By default `npm run build` will use the URL of `https://collections.library.nd.edu` and honeycomb endpoint of `https://honeycomb.library.nd.edu`. You can override these values with the PUBLIC_URL and HONEYCOMB_URL environment variables, ex:
+
+```sh
+PUBLIC_URL=https://collections-test.library.nd.edu \
+HONEYCOMB_URL=https://honeycomb-test.library.nd.edu \
+  npm run build
+```

--- a/build-conf/env.js
+++ b/build-conf/env.js
@@ -20,6 +20,7 @@ const getClientEnvironment = (publicUrl) => {
       // This should only be used as an escape hatch. Normally you would put
       // images into the `src` and `import` them in code to get their paths.
       PUBLIC_URL: publicUrl,
+      HONEYCOMB_URL: process.env.HONEYCOMB_URL || 'https://honeycomb.library.nd.edu',
     })
   // Stringify all values so we can feed into Webpack DefinePlugin
   const stringified = {

--- a/src/components/Collection/Collection.js
+++ b/src/components/Collection/Collection.js
@@ -41,7 +41,7 @@ const Collection = (props) => {
     return null
   }
   PageTitle(collection.name)
-  const url = `https://collections.library.nd.edu/${collection.id}/${collection.slug}`
+  const url = `${process.env.PUBLIC_URL}/${collection.id}/${collection.slug}`
   let data = {
     '@context': 'http://schema.org',
     '@type': 'WebSite',

--- a/src/components/Item/ItemShow.js
+++ b/src/components/Item/ItemShow.js
@@ -41,7 +41,7 @@ const ItemShow = ({ item, collection, title, height }) => {
     const dataProp = item.metadata[property]
     articleBody += `${dataProp.label}:${dataProp.values[0].value}\n`
   }
-  const dataUrl = `https://collections.library.nd.edu/${collection.id}/${collection.slug}/items/${item.id}`
+  const dataUrl = `${process.env.PUBLIC_URL}/${collection.id}/${collection.slug}/items/${item.id}`
   const data = {
     '@context': 'http://schema.org',
     '@type': 'Article',

--- a/src/components/Pages/About.js
+++ b/src/components/Pages/About.js
@@ -54,7 +54,7 @@ const About = createReactClass({
       )
     }
 
-    const dataUrl = `https://collections.library.nd.edu/${collection.id}/${collection.slug}/about`
+    const dataUrl = `${process.env.PUBLIC_URL}/${collection.id}/${collection.slug}/about`
     const data = {
       '@context': 'http://schema.org',
       '@type': 'Article',

--- a/src/components/Pages/Page.js
+++ b/src/components/Pages/Page.js
@@ -80,7 +80,7 @@ const Page = (props) => {
   }
   const pageContent = (collection && collection.pages) ? collection.pages.content : null
   const image = (collection.pages.image && collection.pages.image.contentUrl) ? collection.pages.image.contentUrl : ''
-  const dataUrl = `https://collections.library.nd.edu/${collection.id}/${collection.slug}/${collection.pages.id}/` +
+  const dataUrl = `${process.env.PUBLIC_URL}/${collection.id}/${collection.slug}/${collection.pages.id}/` +
     collection.pages.slug
   const data = {
     '@context': 'http://schema.org',

--- a/src/components/Showcase/ShowcaseShow.js
+++ b/src/components/Showcase/ShowcaseShow.js
@@ -176,7 +176,7 @@ const ShowcaseShow = createReactClass({
     for (let i = 0; i < showcase.sections.length; i++) {
       articleBody += RemoveMarkup(showcase.sections[i].description)
     }
-    const dataUrl = `https://collections.library.nd.edu/${collection.id}/${collection.slug}/showcases/${showcase.id}/` +
+    const dataUrl = `${process.env.PUBLIC_URL}/${collection.id}/${collection.slug}/showcases/${showcase.id}/` +
       showcase.slug
 
     const showcaseSafeImage = showcase.image

--- a/src/components/SiteIndex/index.js
+++ b/src/components/SiteIndex/index.js
@@ -56,7 +56,7 @@ const SiteIndex = createReactClass({
     const data = {
       '@context': 'http://schema.org',
       '@type': 'WebSite',
-      url: 'https://collections.library.nd.edu/',
+      url: process.env.PUBLIC_URL,
       name: 'Digital Exhibits and Collections',
       author: {
         '@type': 'Organization',

--- a/src/modules/HoneycombURL.js
+++ b/src/modules/HoneycombURL.js
@@ -1,11 +1,4 @@
 
 export default function () {
-  if (process.env.NODE_ENV === 'production') {
-    return 'https://honeycomb.library.nd.edu'
-  } else if (process.env.NODE_ENV === 'preproduction') {
-    return 'https://honeycomb-prep.library.nd.edu'
-  } else {
-    return 'https://localhost:3017'
-    // return 'https://honeycomb.library.nd.edu'
-  }
+  return process.env.HONEYCOMB_URL
 }


### PR DESCRIPTION
This is to allow configuring beehive endpoints through env at build time.
Calls to process.env.HONEYCOMB_URL or PUBLIC_URL will get replaced with
the env values at build time, allowing us to point a dev beehive instance
at a dev honeycomb, test at test, prod at prod, etc. For more info see
the react documentation [Adding Custom Environment Variables](https://create-react-app.dev/docs/adding-custom-environment-variables#referencing-environment-variables-in-the-html)